### PR TITLE
Add option to define install options

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -87,6 +87,7 @@
 class proxysql (
   String $package_name = $::proxysql::params::package_name,
   String $package_ensure = $::proxysql::params::package_ensure,
+  Array[String] $package_install_options = $::proxysql::params::package_install_options,
 
   String $service_name = $::proxysql::params::service_name,
   String $service_ensure = $::proxysql::params::service_ensure,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -5,7 +5,8 @@
 class proxysql::install {
 
   package { $::proxysql::package_name:
-    ensure => $::proxysql::package_ensure,
+    ensure          => $::proxysql::package_ensure,
+    install_options => $::proxysql::package_install_options,
   }
 
   file { 'proxysql-datadir':

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,6 +6,7 @@
 class proxysql::params {
   $package_name = 'proxysql'
   $package_ensure = 'installed'
+  $package_install_options = []
 
   $service_name = 'proxysql'
   $service_ensure = 'running'

--- a/spec/classes/proxysql_spec.rb
+++ b/spec/classes/proxysql_spec.rb
@@ -26,7 +26,10 @@ describe 'proxysql' do
 
           it { is_expected.to contain_class('mysql::client').with(bindings_enable: false) }
 
-          it { is_expected.to contain_package('proxysql').with_ensure('installed') }
+          it do
+            is_expected.to contain_package('proxysql').with(ensure: 'installed',
+                                                            install_options: [])
+          end
 
           it do
             is_expected.to contain_file('proxysql-config-file').with(ensure: 'file',


### PR DESCRIPTION
The package_install_options parameter will be given to the package
resource in install_option.
https://docs.puppet.com/puppet/latest/type.html#package-attribute-install_options

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
