### PR TITLE
Deleting non UTF8-char

### DIFF
--- a/lib/puppet/type/proxy_mysql_query_rule.rb
+++ b/lib/puppet/type/proxy_mysql_query_rule.rb
@@ -138,7 +138,7 @@ Puppet::Type.newtype(:proxy_mysql_query_rule) do
   end
 
   newproperty(:error_msg) do
-    desc 'query will be blocked, and the specified error_msg will be returned to the clientß.'
+    desc 'query will be blocked, and the specified error_msg will be returned to the client.'
     newvalue(%r{\w+})
   end
 


### PR DESCRIPTION
Fix an issue when error_msg was called:

`Error: Error while evaluating a Resource Statement, Could not autoload puppet/type/proxy_mysql_query_rule: /etc/puppetlabs/code/environments/devel/modules/proxysql/lib/puppet/type/proxy_mysql_query_rule.rb:142: invalid multibyte char (US-ASCII)`

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
