### PR TITLE
config file: owner and group configurable (fix)

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -11,8 +11,8 @@ class proxysql::config {
       path                    => $proxysql::config_file,
       content                 => template('proxysql/proxysql.cnf.erb'),
       mode                    => '0640',
-      owner                   => $proxysql::params::sys_owner,
-      group                   => $proxysql::params::sys_group,
+      owner                   => $proxysql::sys_owner,
+      group                   => $proxysql::sys_group,
       selinux_ignore_defaults => true,
     }
   }
@@ -22,8 +22,8 @@ class proxysql::config {
       ensure  => file,
       path    => $proxysql::mycnf_file_name,
       content => template('proxysql/my.cnf.erb'),
-      owner   => $proxysql::params::sys_owner,
-      group   => $proxysql::params::sys_group,
+      owner   => $proxysql::sys_owner,
+      group   => $proxysql::sys_group,
       mode    => '0400',
     }
   }


### PR DESCRIPTION
the user/group owner of the config file and my.cnf file was actually unconfigurable because it took the value out of proxysql::params.