### PR TITLE
Fixed managing admin credentials

### DIFF
--- a/manifests/admin_credentials.pp
+++ b/manifests/admin_credentials.pp
@@ -1,0 +1,37 @@
+# == Class proxysql::admin_credentials
+#
+# This class is called from proxysql for service config.
+#
+class proxysql::admin_credentials {
+
+  if $proxysql::manage_mycnf_file {
+    $mycnf_file_name = $proxysql::mycnf_file_name
+    $admin_credentials = $proxysql::config_settings['admin_variables']['admin_credentials']
+    $admin_interfaces = $proxysql::config_settings['admin_variables']['mysql_ifaces']
+    exec { 'proxysql-admin-credentials':
+      command => "/usr/bin/mysql --defaults-extra-file=${mycnf_file_name} --execute=\"
+        SET admin-admin_credentials = '${admin_credentials}'; \
+        SET admin-mysql_ifaces = '${admin_interfaces}'; \
+        LOAD ADMIN VARIABLES TO RUNTIME; \
+        SAVE ADMIN VARIABLES TO DISK;\"
+      ",
+      onlyif  => "/usr/bin/test \
+        `/usr/bin/mysql --defaults-extra-file=${mycnf_file_name} -BN \
+          --execute=\"SELECT variable_value FROM global_variables WHERE variable_name='admin-admin_credentials'\"` != '${admin_credentials}' \
+        -o `/usr/bin/mysql --defaults-extra-file=${mycnf_file_name} -BN \
+          --execute=\"SELECT variable_value FROM global_variables WHERE variable_name='admin-mysql_ifaces'\"` != '${admin_interfaces}'
+      ",
+      before  => File['root-mycnf-file'],
+    }
+
+    file { 'root-mycnf-file':
+      ensure  => file,
+      path    => $proxysql::mycnf_file_name,
+      content => template('proxysql/my.cnf.erb'),
+      owner   => $proxysql::sys_owner,
+      group   => $proxysql::sys_group,
+      mode    => '0400',
+    }
+  }
+
+}

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -17,28 +17,4 @@ class proxysql::config {
     }
   }
 
-  proxy_global_variable { 'admin-admin_credentials':
-    value           => $config_settings['admin_variables']['admin_credentials'],
-    load_to_runtime => false,
-    notify          => Service[$::proxysql::service_name],
-    before          => File['root-mycnf-file'],
-  }
-
-  proxy_global_variable { 'admin-mysql_ifaces':
-    value           => $config_settings['admin_variables']['mysql_ifaces'],
-    load_to_runtime => false,
-    notify          => Service[$::proxysql::service_name],
-    before          => File['root-mycnf-file'],
-  }
-
-  if $proxysql::manage_mycnf_file {
-    file { 'root-mycnf-file':
-      ensure  => file,
-      path    => $proxysql::mycnf_file_name,
-      content => template('proxysql/my.cnf.erb'),
-      owner   => $proxysql::sys_owner,
-      group   => $proxysql::sys_group,
-      mode    => '0400',
-    }
-  }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,7 +43,8 @@
 #   The port where the ProxySQL admin interface  will listen on. Defaults to '6032'
 #
 # * `admin_listen_socket`
-#   The socket where the ProxySQL admin interface  will listen on. Defaults to '/tmp/proxysql_admin.sock'
+#   The socket where the ProxySQL admin interface  will listen on. Changing this on a running system will result in failing runs.
+#   Defaults to '/tmp/proxysql_admin.sock'
 #
 # * `monitor_username`
 #   The username ProxySQL will use to connect to the configured mysql_servers. Defaults to 'monitor'
@@ -63,7 +64,8 @@
 #   This will only be configured if `manage_mycnf_file` is set to `true`. Defaults to '/root/.my.cnf'
 #
 # * `manage_mycnf_file`
-#   Determines wheter this module will configure the my.cnf file to connect to the admin interface. Defaults to 'true'
+#   Determines wheter this module will configure the my.cnf file to connect to the admin interface.
+#   This is required for the providers to work. Defaults to 'true'
 #
 # * `restart`
 #   Determines wheter this module will restart ProxySQL after reconfiguring the config file. Defaults to 'false'
@@ -179,6 +181,7 @@ class proxysql (
   -> class { '::proxysql::install':}
   -> class { '::proxysql::config':}
   -> class { '::proxysql::service':}
+  -> class { '::proxysql::admin_credentials':}
   -> anchor { '::proxysql::end': }
 
   Class['::proxysql::install']

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -6,11 +6,7 @@
 class proxysql::service {
 
   if $::proxysql::manage_config_file {
-    if $::proxysql::manage_mycnf_file {
-      $service_require = [ File['proxysql-config-file'], File['root-mycnf-file'] ]
-    } else {
-      $service_require = File['proxysql-config-file']
-    }
+    $service_require = File['proxysql-config-file']
   } else {
     $service_require = undef
   }


### PR DESCRIPTION
moved managing the admin credentials to be executed after the service is running.
these crednetials can't be managed with the existing providers as that creates a dependency cycle...

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
