### PR TITLE
Change the user and group under which proxysql runs on Debian systems

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,14 +23,14 @@ class proxysql::params {
   $admin_listen_ip     = '127.0.0.1'
   $admin_listen_port   = 6032
 
-  case $::operatingsystem {
-    'Debian', 'Ubuntu': {
+  case $facts['os']['family'] {
+    'Debian': {
       $admin_listen_socket = '/tmp/proxysql_admin.sock'
       $package_provider    = 'dpkg'
       $sys_owner           = 'proxysql'
       $sys_group           = 'proxysql'
     }
-    'CentOS', 'Fedora', 'Scientific', 'RedHat', 'Amazon', 'OracleLinux': {
+    'RedHat': {
       $admin_listen_socket = '/tmp/proxysql_admin.sock'
       $package_provider    = 'rpm'
       $sys_owner           = 'proxysql'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,13 +24,7 @@ class proxysql::params {
   $admin_listen_port   = 6032
 
   case $::operatingsystem {
-    'Debian': {
-      $admin_listen_socket = '/tmp/proxysql_admin.sock'
-      $package_provider    = 'dpkg'
-      $sys_owner           = 'root'
-      $sys_group           = 'root'
-    }
-    'Ubuntu': {
+    'Debian', 'Ubuntu': {
       $admin_listen_socket = '/tmp/proxysql_admin.sock'
       $package_provider    = 'dpkg'
       $sys_owner           = 'proxysql'

--- a/spec/classes/proxysql_spec.rb
+++ b/spec/classes/proxysql_spec.rb
@@ -32,10 +32,7 @@ describe 'proxysql' do
           end
 
           case facts[:operatingsystem]
-          when 'Debian' then
-            let(:sys_user) { 'root' }
-            let(:sys_group) { 'root' }
-          when 'Ubuntu' then
+          when 'Debian', 'Ubuntu' then
             let(:sys_user) { 'proxysql' }
             let(:sys_group) { 'proxysql' }
           when 'CentOS', 'Fedora', 'Scientific', 'RedHat', 'Amazon', 'OracleLinux' then

--- a/spec/classes/proxysql_spec.rb
+++ b/spec/classes/proxysql_spec.rb
@@ -31,11 +31,11 @@ describe 'proxysql' do
                                                             install_options: [])
           end
 
-          case facts[:operatingsystem]
-          when 'Debian', 'Ubuntu' then
+          case facts[:osfamily]
+          when 'Debian' then
             let(:sys_user) { 'proxysql' }
             let(:sys_group) { 'proxysql' }
-          when 'CentOS', 'Fedora', 'Scientific', 'RedHat', 'Amazon', 'OracleLinux' then
+          when 'RedHat' then
             let(:sys_user) { 'proxysql' }
             let(:sys_group) { 'proxysql' }
           else


### PR DESCRIPTION
On Debian systems proxysql should be running under the `proxysql` user and group, instead of `root`.
The configuration files should also be owned by this user and group.

I initially started looking to see when the Debian version might have switched from using the `root` account to `proxysql`, so that I could use a version check in `params.pp` but I could not find any time when it did. Therefore I thought it best to merge the case blocks for Ubuntu and Debian into one.