### PR TITLE
add support for multiple admin users

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -226,6 +226,8 @@ key utl for the yumrepo-resource in RedHat-based systems, defaults to 'https://w
 ##### `override_config_settings`
 Which configuration variables should be overriden. Hash, defaults to {} (empty hash).
 
+##### `admin_users`
+Array of users, for which .my.cnf file will be copied to their home directory. Defaults to []
 
 ## Types
 #### proxy_global_variable

--- a/manifests/admin_credentials.pp
+++ b/manifests/admin_credentials.pp
@@ -6,8 +6,10 @@ class proxysql::admin_credentials {
 
   if $proxysql::manage_mycnf_file {
     $mycnf_file_name = $proxysql::mycnf_file_name
+    $admin_users = $proxysql::admin_users
     $admin_credentials = $proxysql::config_settings['admin_variables']['admin_credentials']
     $admin_interfaces = $proxysql::config_settings['admin_variables']['mysql_ifaces']
+    # lint:ignore:140chars
     exec { 'proxysql-admin-credentials':
       command => "/usr/bin/mysql --defaults-extra-file=${mycnf_file_name} --execute=\"
         SET admin-admin_credentials = '${admin_credentials}'; \
@@ -23,14 +25,26 @@ class proxysql::admin_credentials {
       ",
       before  => File['root-mycnf-file'],
     }
+    # lint:endignore
 
     file { 'root-mycnf-file':
       ensure  => file,
       path    => $proxysql::mycnf_file_name,
       content => template('proxysql/my.cnf.erb'),
-      owner   => $proxysql::sys_owner,
-      group   => $proxysql::sys_group,
-      mode    => '0400',
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0640',
+    }
+
+    $admin_users.each |String $user| {
+      file { "${::user}-mycnf-file":
+        ensure  => file,
+        path    => "/home/${user}/.my.cnf",
+        content => template('proxysql/my.cnf.erb'),
+        owner   => $user,
+        group   => 'root',
+        mode    => '0640',
+      }
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -110,6 +110,9 @@
 # * `override_config_settings`
 #   Which configuration variables should be overriden. Hash, defaults to {} (empty hash).
 #
+# * `admin_users`
+#   Array of users, for which .my.cnf file will be copied to their home directory. Defaults to []
+#
 class proxysql (
   String $package_name = $::proxysql::params::package_name,
   String $package_ensure = $::proxysql::params::package_ensure,
@@ -158,6 +161,8 @@ class proxysql (
   String $rpm_repo_key    =  $::proxysql::params::rpm_repo_key,
 
   Hash $override_config_settings = {},
+
+  Array[String] $admin_users = $::proxysql::params::admin_users,
 ) inherits ::proxysql::params {
 
   # lint:ignore:80chars

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -72,6 +72,8 @@ class proxysql::params {
   $rpm_repo        = 'http://repo.percona.com/release/$releasever/RPMS/$basearch'
   $rpm_repo_key    = 'https://www.percona.com/downloads/RPM-GPG-KEY-percona'
 
+  $admin_users = []
+
   $config_settings = {
     datadir => $datadir,
     admin_variables => {

--- a/spec/classes/proxysql_spec.rb
+++ b/spec/classes/proxysql_spec.rb
@@ -64,9 +64,9 @@ describe 'proxysql' do
 
           it do
             is_expected.to contain_file('root-mycnf-file').with(ensure: 'file',
-                                                                owner: sys_user,
-                                                                group: sys_group,
-                                                                mode: '0400',
+                                                                owner: 'root',
+                                                                group: 'root',
+                                                                mode: '0640',
                                                                 path: '/root/.my.cnf')
           end
 


### PR DESCRIPTION
Add `$admin_users` param. It's array of Linux users, for which we will copy .my.cnf file in their home directory to allow manage ProxySQL