### PR TITLE
support purging for all types of resources

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1470,8 +1470,6 @@ Valid values: `%r{[01]}`
 
 Backend or not.
 
-Default value: `1`
-
 ##### `default_hostgroup`
 
 Valid values: `%r{\d+}`
@@ -1503,8 +1501,6 @@ Use fast forwrd or not.
 Valid values: `%r{[01]}`
 
 Frontend or not.
-
-Default value: `1`
 
 ##### `max_connections`
 

--- a/lib/puppet/provider/proxy_mysql_group_replication_hostgroup/proxysql.rb
+++ b/lib/puppet/provider/proxy_mysql_group_replication_hostgroup/proxysql.rb
@@ -66,12 +66,12 @@ Puppet::Type.type(:proxy_mysql_group_replication_hostgroup).provide(:proxysql, p
   end
 
   def destroy
-    writer_hostgroup = @resource.value(:writer_hostgroup)
-    backup_writer_hostgroup = @resource.value(:backup_writer_hostgroup)
-    reader_hostgroup = @resource.value(:reader_hostgroup)
-    offline_hostgroup = @resource.value(:offline_hostgroup)
-    query = 'DELETE FROM `mysql_group_replication_hostgroups` ' \
-            "WHERE `writer_hostgroup` =  #{writer_hostgroup} AND `backup_writer_hostgroup` = #{backup_writer_hostgroup} AND `reader_hostgroup` = #{reader_hostgroup} AND `offline_hostgroup` = #{offline_hostgroup}"
+    writer_hostgroup = @property_hash[:writer_hostgroup]
+    backup_writer_hostgroup = @property_hash[:backup_writer_hostgroup]
+    reader_hostgroup = @property_hash[:reader_hostgroup]
+    offline_hostgroup = @property_hash[:offline_hostgroup]
+    query = 'DELETE FROM `mysql_group_replication_hostgroups`'
+    query << " WHERE `writer_hostgroup` =  #{writer_hostgroup} AND `backup_writer_hostgroup` = #{backup_writer_hostgroup} AND `reader_hostgroup` = #{reader_hostgroup} AND `offline_hostgroup` = #{offline_hostgroup}"
     mysql([defaults_file, '-e', query].compact)
 
     @property_hash.clear

--- a/lib/puppet/provider/proxy_mysql_query_rule/proxysql.rb
+++ b/lib/puppet/provider/proxy_mysql_query_rule/proxysql.rb
@@ -131,7 +131,7 @@ Puppet::Type.type(:proxy_mysql_query_rule).provide(:proxysql, parent: Puppet::Pr
   end
 
   def destroy
-    rule_id = @resource.value(:rule_id)
+    rule_id = @property_hash[:rule_id]
     mysql([defaults_file, '-e', "DELETE FROM `mysql_query_rules` WHERE `rule_id` = '#{rule_id}'"].compact)
 
     @property_hash.clear

--- a/lib/puppet/provider/proxy_mysql_replication_hostgroup/proxysql.rb
+++ b/lib/puppet/provider/proxy_mysql_replication_hostgroup/proxysql.rb
@@ -54,8 +54,8 @@ Puppet::Type.type(:proxy_mysql_replication_hostgroup).provide(:proxysql, parent:
   end
 
   def destroy
-    writer_hostgroup = @resource.value(:writer_hostgroup)
-    reader_hostgroup = @resource.value(:reader_hostgroup)
+    writer_hostgroup = @property_hash[:writer_hostgroup]
+    reader_hostgroup = @property_hash[:reader_hostgroup]
     query = 'DELETE FROM `mysql_replication_hostgroups` ' \
             "WHERE `writer_hostgroup` =  #{writer_hostgroup} AND `reader_hostgroup` = #{reader_hostgroup}"
     mysql([defaults_file, '-e', query].compact)

--- a/lib/puppet/provider/proxy_mysql_server/proxysql.rb
+++ b/lib/puppet/provider/proxy_mysql_server/proxysql.rb
@@ -80,9 +80,9 @@ Puppet::Type.type(:proxy_mysql_server).provide(:proxysql, parent: Puppet::Provid
   end
 
   def destroy
-    hostname = @resource.value(:hostname)
-    port = @resource.value(:port)
-    hostgroup_id = @resource.value(:hostgroup_id)
+    hostname = @property_hash[:hostname]
+    port = @property_hash[:port]
+    hostgroup_id = @property_hash[:hostgroup_id]
     query = 'DELETE FROM `mysql_servers` ' \
             "WHERE `hostname` =  '#{hostname}' AND `port` = #{port} AND `hostgroup_id` = '#{hostgroup_id}'"
     mysql([defaults_file, '-e', query].compact)

--- a/lib/puppet/provider/proxy_mysql_server_no_hostgroup/proxysql.rb
+++ b/lib/puppet/provider/proxy_mysql_server_no_hostgroup/proxysql.rb
@@ -80,8 +80,8 @@ Puppet::Type.type(:proxy_mysql_server_no_hostgroup).provide(:proxysql, parent: P
   end
 
   def destroy
-    hostname = @resource.value(:hostname)
-    port = @resource.value(:port)
+    hostname = @property_hash[:hostname]
+    port = @property_hash[:port]
 
     query = "DELETE FROM `mysql_servers` WHERE `hostname` = '#{hostname}' AND `port` = #{port}"
     mysql([defaults_file, '-e', query].compact)

--- a/lib/puppet/provider/proxy_mysql_user/proxysql.rb
+++ b/lib/puppet/provider/proxy_mysql_user/proxysql.rb
@@ -72,7 +72,7 @@ Puppet::Type.type(:proxy_mysql_user).provide(:proxysql, parent: Puppet::Provider
   end
 
   def destroy
-    name = @resource[:name]
+    name = @property_hash[:name]
     mysql([defaults_file, '-e', "DELETE FROM mysql_users WHERE username = '#{name}'"].compact)
 
     @property_hash.clear

--- a/lib/puppet/provider/proxy_scheduler/proxysql.rb
+++ b/lib/puppet/provider/proxy_scheduler/proxysql.rb
@@ -72,7 +72,7 @@ Puppet::Type.type(:proxy_scheduler).provide(:proxysql, parent: Puppet::Provider:
   end
 
   def destroy
-    scheduler_id = @resource.value(:scheduler_id)
+    scheduler_id = @property_hash[:scheduler_id]
 
     mysql([defaults_file, '-e', "DELETE FROM `scheduler` WHERE `id` = #{scheduler_id}"].compact)
 

--- a/lib/puppet/type/proxy_mysql_group_replication_hostgroup.rb
+++ b/lib/puppet/type/proxy_mysql_group_replication_hostgroup.rb
@@ -15,7 +15,7 @@ Puppet::Type.newtype(:proxy_mysql_group_replication_hostgroup) do
     raise('backup_writer_hostgroup parameter is required.') if (self[:ensure] == :present) && self[:backup_writer_hostgroup].nil?
     raise('reader_hostgroup parameter is required.') if (self[:ensure] == :present) && self[:reader_hostgroup].nil?
     raise('offline_hostgroup parameter is required.') if (self[:ensure] == :present) && self[:offline_hostgroup].nil?
-    raise('name must match writer_hostgroup-backup_writer_hostgroup-reader_hostgroup-offline_hostgroup parameters') if self[:name] != "#{self[:writer_hostgroup]}-#{self[:backup_writer_hostgroup]}-#{self[:reader_hostgroup]}-#{self[:offline_hostgroup]}"
+    raise('name must match writer_hostgroup-backup_writer_hostgroup-reader_hostgroup-offline_hostgroup parameters') if (self[:ensure] == :present) && self[:name] != "#{self[:writer_hostgroup]}-#{self[:backup_writer_hostgroup]}-#{self[:reader_hostgroup]}-#{self[:offline_hostgroup]}"
   end
 
   newparam(:name, namevar: true) do

--- a/lib/puppet/type/proxy_mysql_query_rule.rb
+++ b/lib/puppet/type/proxy_mysql_query_rule.rb
@@ -10,8 +10,8 @@ Puppet::Type.newtype(:proxy_mysql_query_rule) do
   autorequire(:service) { 'proxysql' }
 
   validate do
-    raise('rule_id parameter is required.') if self[:rule_id].nil?
-    raise('name must match \'mysql_query_rule-\'<rule_id> format') if self[:name] != "mysql_query_rule-#{self[:rule_id]}"
+    raise('rule_id parameter is required.') if (self[:ensure] == :present) && self[:rule_id].nil?
+    raise('name must match \'mysql_query_rule-\'<rule_id> format') if (self[:ensure] == :present) && self[:name] != "mysql_query_rule-#{self[:rule_id]}"
   end
 
   newparam(:name, namevar: true) do

--- a/lib/puppet/type/proxy_mysql_replication_hostgroup.rb
+++ b/lib/puppet/type/proxy_mysql_replication_hostgroup.rb
@@ -13,7 +13,7 @@ Puppet::Type.newtype(:proxy_mysql_replication_hostgroup) do
   validate do
     raise('writer_hostgroup parameter is required.') if (self[:ensure] == :present) && self[:writer_hostgroup].nil?
     raise('reader_hostgroup parameter is required.') if (self[:ensure] == :present) && self[:reader_hostgroup].nil?
-    raise('name must match writer_hostgroup-reader_hostgroup parameters') if self[:name] != "#{self[:writer_hostgroup]}-#{self[:reader_hostgroup]}"
+    raise('name must match writer_hostgroup-reader_hostgroup parameters') if (self[:ensure] == :present) && self[:name] != "#{self[:writer_hostgroup]}-#{self[:reader_hostgroup]}"
   end
 
   newparam(:name, namevar: true) do

--- a/lib/puppet/type/proxy_mysql_server.rb
+++ b/lib/puppet/type/proxy_mysql_server.rb
@@ -14,7 +14,7 @@ Puppet::Type.newtype(:proxy_mysql_server) do
     raise('hostname parameter is required.') if (self[:ensure] == :present) && self[:hostname].nil?
     raise('port parameter is required.') if (self[:ensure] == :present) && self[:port].nil?
     raise('hostgroup_id parameter is required.') if (self[:ensure] == :present) && self[:hostgroup_id].nil?
-    raise('name must match hostname, port and hostgroup_id parameters') if self[:name] != "#{self[:hostname]}:#{self[:port]}-#{self[:hostgroup_id]}"
+    raise('name must match hostname, port and hostgroup_id parameters') if (self[:ensure] == :present) && self[:name] != "#{self[:hostname]}:#{self[:port]}-#{self[:hostgroup_id]}"
   end
 
   newparam(:name, namevar: true) do

--- a/lib/puppet/type/proxy_mysql_server_no_hostgroup.rb
+++ b/lib/puppet/type/proxy_mysql_server_no_hostgroup.rb
@@ -14,7 +14,7 @@ Puppet::Type.newtype(:proxy_mysql_server_no_hostgroup) do
     raise('hostname parameter is required.') if (self[:ensure] == :present) && self[:hostname].nil?
     raise('port parameter is required.') if (self[:ensure] == :present) && self[:port].nil?
     raise('hostgroup_id parameter is required.') if (self[:ensure] == :present) && self[:hostgroup_id].nil?
-    raise('name must match hostname and port') if self[:name] != "#{self[:hostname]}:#{self[:port]}"
+    raise('name must match hostname and port') if (self[:ensure] == :present) && self[:name] != "#{self[:hostname]}:#{self[:port]}"
   end
 
   newparam(:name, namevar: true) do

--- a/lib/puppet/type/proxy_mysql_user.rb
+++ b/lib/puppet/type/proxy_mysql_user.rb
@@ -15,6 +15,8 @@ Puppet::Type.newtype(:proxy_mysql_user) do
   def initialize(*args)
     super
 
+    return if self[:ensure] != :present
+
     self[:password] = "*#{Digest::SHA1.hexdigest(Digest::SHA1.digest(self[:password])).upcase}" unless self[:password].start_with?('*') || self[:encrypt_password] != :true
   end
 
@@ -82,13 +84,11 @@ Puppet::Type.newtype(:proxy_mysql_user) do
 
   newproperty(:backend) do
     desc 'Backend or not.'
-    defaultto 1
     newvalue(%r{[01]})
   end
 
   newproperty(:frontend) do
     desc 'Frontend or not.'
-    defaultto 1
     newvalue(%r{[01]})
   end
 

--- a/lib/puppet/type/proxy_scheduler.rb
+++ b/lib/puppet/type/proxy_scheduler.rb
@@ -10,9 +10,9 @@ Puppet::Type.newtype(:proxy_scheduler) do
   autorequire(:service) { 'proxysql' }
 
   validate do
-    raise('scheduler_id parameter is required.') if self[:scheduler_id].nil?
+    raise('scheduler_id parameter is required.') if (self[:ensure] == :present) && self[:scheduler_id].nil?
     raise('filename parameter is required.') if (self[:ensure] == :present) && self[:filename].nil?
-    raise('name must match \'scheduler-\'<scheduler_id> format') if self[:name] != "scheduler-#{self[:scheduler_id]}"
+    raise('name must match \'scheduler-\'<scheduler_id> format') if (self[:ensure] == :present) && self[:name] != "scheduler-#{self[:scheduler_id]}"
   end
 
   newparam(:name, namevar: true) do

--- a/spec/types/proxy_cluster_spec.rb
+++ b/spec/types/proxy_cluster_spec.rb
@@ -2,26 +2,24 @@
 
 require 'spec_helper'
 
-describe 'proxy_mysql_galera_hostgroup' do
+describe 'proxy_cluster' do
   let :title do
-    '1-2-3-4'
+    'some-title'
   end
 
   let(:params) do
     {
       ensure: 'present',
-      name: '10-20-30-40',
-      writer_hostgroup: 10,
-      backup_writer_hostgroup: 20,
-      reader_hostgroup: 30,
-      offline_hostgroup: 40
+      name: 'some-name',
+      hostname: 'some-host',
+      port: 1234,
     }
   end
 
   context 'with ensure => present' do
     it { is_expected.to be_valid_type }
     it { is_expected.to be_valid_type.with_provider(:proxysql) }
-    it { is_expected.to be_valid_type.with_parameters(%w[writer_hostgroup backup_writer_hostgroup reader_hostgroup offline_hostgroup load_to_runtime save_to_disk]) }
+    it { is_expected.to be_valid_type.with_parameters(%w[name load_to_runtime save_to_disk]) }
   end
 
   context 'with ensure => absent' do

--- a/spec/types/proxy_global_variable_spec.rb
+++ b/spec/types/proxy_global_variable_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'proxy_global_variable' do
+  let :title do
+    'some-variable'
+  end
+
+  let(:params) do
+    {
+      value: 'some-value',
+    }
+  end
+
+  it { is_expected.to be_valid_type }
+  it { is_expected.to be_valid_type.with_provider(:proxysql) }
+  it { is_expected.to be_valid_type.with_parameters(%w[name load_to_runtime save_to_disk]) }
+end

--- a/spec/types/proxy_mysql_group_replication_hostgroup_spec.rb
+++ b/spec/types/proxy_mysql_group_replication_hostgroup_spec.rb
@@ -2,9 +2,9 @@
 
 require 'spec_helper'
 
-describe 'proxy_mysql_galera_hostgroup' do
+describe 'proxy_mysql_group_replication_hostgroup' do
   let :title do
-    '1-2-3-4'
+    'some-title'
   end
 
   let(:params) do
@@ -21,7 +21,7 @@ describe 'proxy_mysql_galera_hostgroup' do
   context 'with ensure => present' do
     it { is_expected.to be_valid_type }
     it { is_expected.to be_valid_type.with_provider(:proxysql) }
-    it { is_expected.to be_valid_type.with_parameters(%w[writer_hostgroup backup_writer_hostgroup reader_hostgroup offline_hostgroup load_to_runtime save_to_disk]) }
+    it { is_expected.to be_valid_type.with_parameters(%w[name load_to_runtime save_to_disk]) }
   end
 
   context 'with ensure => absent' do

--- a/spec/types/proxy_mysql_query_rule_spec.rb
+++ b/spec/types/proxy_mysql_query_rule_spec.rb
@@ -2,26 +2,23 @@
 
 require 'spec_helper'
 
-describe 'proxy_mysql_galera_hostgroup' do
+describe 'proxy_mysql_query_rule' do
   let :title do
-    '1-2-3-4'
+    'some-title'
   end
 
   let(:params) do
     {
       ensure: 'present',
-      name: '10-20-30-40',
-      writer_hostgroup: 10,
-      backup_writer_hostgroup: 20,
-      reader_hostgroup: 30,
-      offline_hostgroup: 40
+      name: 'mysql_query_rule-10',
+      rule_id: 10,
     }
   end
 
   context 'with ensure => present' do
     it { is_expected.to be_valid_type }
     it { is_expected.to be_valid_type.with_provider(:proxysql) }
-    it { is_expected.to be_valid_type.with_parameters(%w[writer_hostgroup backup_writer_hostgroup reader_hostgroup offline_hostgroup load_to_runtime save_to_disk]) }
+    it { is_expected.to be_valid_type.with_parameters(%w[name load_to_runtime save_to_disk]) }
   end
 
   context 'with ensure => absent' do

--- a/spec/types/proxy_mysql_replication_hostgroup_spec.rb
+++ b/spec/types/proxy_mysql_replication_hostgroup_spec.rb
@@ -2,26 +2,24 @@
 
 require 'spec_helper'
 
-describe 'proxy_mysql_galera_hostgroup' do
+describe 'proxy_mysql_replication_hostgroup' do
   let :title do
-    '1-2-3-4'
+    'some-title'
   end
 
   let(:params) do
     {
       ensure: 'present',
-      name: '10-20-30-40',
+      name: '10-30',
       writer_hostgroup: 10,
-      backup_writer_hostgroup: 20,
-      reader_hostgroup: 30,
-      offline_hostgroup: 40
+      reader_hostgroup: 30
     }
   end
 
   context 'with ensure => present' do
     it { is_expected.to be_valid_type }
     it { is_expected.to be_valid_type.with_provider(:proxysql) }
-    it { is_expected.to be_valid_type.with_parameters(%w[writer_hostgroup backup_writer_hostgroup reader_hostgroup offline_hostgroup load_to_runtime save_to_disk]) }
+    it { is_expected.to be_valid_type.with_parameters(%w[name load_to_runtime save_to_disk]) }
   end
 
   context 'with ensure => absent' do

--- a/spec/types/proxy_mysql_server_no_hostgroup_spec.rb
+++ b/spec/types/proxy_mysql_server_no_hostgroup_spec.rb
@@ -2,26 +2,25 @@
 
 require 'spec_helper'
 
-describe 'proxy_mysql_galera_hostgroup' do
+describe 'proxy_mysql_server_no_hostgroup' do
   let :title do
-    '1-2-3-4'
+    'some-title'
   end
 
   let(:params) do
     {
       ensure: 'present',
-      name: '10-20-30-40',
-      writer_hostgroup: 10,
-      backup_writer_hostgroup: 20,
-      reader_hostgroup: 30,
-      offline_hostgroup: 40
+      name: 'localhost:3306',
+      hostgroup_id: 10,
+      hostname: 'localhost',
+      port: 3306,
     }
   end
 
   context 'with ensure => present' do
     it { is_expected.to be_valid_type }
     it { is_expected.to be_valid_type.with_provider(:proxysql) }
-    it { is_expected.to be_valid_type.with_parameters(%w[writer_hostgroup backup_writer_hostgroup reader_hostgroup offline_hostgroup load_to_runtime save_to_disk]) }
+    it { is_expected.to be_valid_type.with_parameters(%w[name load_to_runtime save_to_disk]) }
   end
 
   context 'with ensure => absent' do

--- a/spec/types/proxy_mysql_server_spec.rb
+++ b/spec/types/proxy_mysql_server_spec.rb
@@ -2,26 +2,25 @@
 
 require 'spec_helper'
 
-describe 'proxy_mysql_galera_hostgroup' do
+describe 'proxy_mysql_server' do
   let :title do
-    '1-2-3-4'
+    'some-title'
   end
 
   let(:params) do
     {
       ensure: 'present',
-      name: '10-20-30-40',
-      writer_hostgroup: 10,
-      backup_writer_hostgroup: 20,
-      reader_hostgroup: 30,
-      offline_hostgroup: 40
+      name: 'localhost:3306-10',
+      hostgroup_id: 10,
+      hostname: 'localhost',
+      port: 3306,
     }
   end
 
   context 'with ensure => present' do
     it { is_expected.to be_valid_type }
     it { is_expected.to be_valid_type.with_provider(:proxysql) }
-    it { is_expected.to be_valid_type.with_parameters(%w[writer_hostgroup backup_writer_hostgroup reader_hostgroup offline_hostgroup load_to_runtime save_to_disk]) }
+    it { is_expected.to be_valid_type.with_parameters(%w[name load_to_runtime save_to_disk]) }
   end
 
   context 'with ensure => absent' do

--- a/spec/types/proxy_mysql_user_spec.rb
+++ b/spec/types/proxy_mysql_user_spec.rb
@@ -2,26 +2,22 @@
 
 require 'spec_helper'
 
-describe 'proxy_mysql_galera_hostgroup' do
+describe 'proxy_mysql_user' do
   let :title do
-    '1-2-3-4'
+    'some-title'
   end
 
   let(:params) do
     {
       ensure: 'present',
-      name: '10-20-30-40',
-      writer_hostgroup: 10,
-      backup_writer_hostgroup: 20,
-      reader_hostgroup: 30,
-      offline_hostgroup: 40
+      password: 'somePassword'
     }
   end
 
   context 'with ensure => present' do
     it { is_expected.to be_valid_type }
     it { is_expected.to be_valid_type.with_provider(:proxysql) }
-    it { is_expected.to be_valid_type.with_parameters(%w[writer_hostgroup backup_writer_hostgroup reader_hostgroup offline_hostgroup load_to_runtime save_to_disk]) }
+    it { is_expected.to be_valid_type.with_parameters(%w[name load_to_runtime save_to_disk]) }
   end
 
   context 'with ensure => absent' do

--- a/spec/types/proxy_scheduler_spec.rb
+++ b/spec/types/proxy_scheduler_spec.rb
@@ -2,26 +2,24 @@
 
 require 'spec_helper'
 
-describe 'proxy_mysql_galera_hostgroup' do
+describe 'proxy_scheduler' do
   let :title do
-    '1-2-3-4'
+    'some-title'
   end
 
   let(:params) do
     {
       ensure: 'present',
-      name: '10-20-30-40',
-      writer_hostgroup: 10,
-      backup_writer_hostgroup: 20,
-      reader_hostgroup: 30,
-      offline_hostgroup: 40
+      name: 'scheduler-10',
+      scheduler_id: 10,
+      filename: '/usr/bin/id'
     }
   end
 
   context 'with ensure => present' do
     it { is_expected.to be_valid_type }
     it { is_expected.to be_valid_type.with_provider(:proxysql) }
-    it { is_expected.to be_valid_type.with_parameters(%w[writer_hostgroup backup_writer_hostgroup reader_hostgroup offline_hostgroup load_to_runtime save_to_disk]) }
+    it { is_expected.to be_valid_type.with_parameters(%w[name load_to_runtime save_to_disk]) }
   end
 
   context 'with ensure => absent' do


### PR DESCRIPTION
Hello,

right now in some resources we have 
```puppet
  validate do
    raise('name parameter is required.') if (self[:ensure] == :present) && self[:name].nil?
    raise('hostname parameter is required.') if (self[:ensure] == :present) && self[:hostname].nil?
    raise('port parameter is required.') if (self[:ensure] == :present) && self[:port].nil?
  end
```

so the error is raised only in case if the resource should be present, but for some, it is not true.
So let's make this equal for all resource types and support purging for all of them