### PR TITLE
fix a bug related to user update failed in case of proxysql cluster

### DIFF
--- a/lib/puppet/provider/proxy_mysql_user/proxysql.rb
+++ b/lib/puppet/provider/proxy_mysql_user/proxysql.rb
@@ -55,14 +55,28 @@ Puppet::Type.type(:proxy_mysql_user).provide(:proxysql, parent: Puppet::Provider
     schema_locked = @resource.value(:schema_locked) || 0
     transaction_persistent = @resource.value(:transaction_persistent) || 1
     fast_forward = @resource.value(:fast_forward) || 0
-    backend = @resource.value(:backend) || 1
-    frontend = @resource.value(:frontend) || 1
+    backend = @resource.value(:backend)
+    frontend = @resource.value(:frontend)
     max_connections = @resource.value(:max_connections) || 10_000
 
     query = 'INSERT INTO mysql_users (`username`, `password`, `active`, `use_ssl`, `default_hostgroup`, `default_schema`, '
-    query << ' `schema_locked`, `transaction_persistent`, `fast_forward`, `backend`, `frontend`, `max_connections`) '
+    query << ' `schema_locked`, `transaction_persistent`, `fast_forward`, '
+    if defined?(backend).nil?
+      query << ' `backend`,'
+    end
+    if defined?(frontend).nil?
+      query << ' `frontend`,'
+    end
+    query << ' `max_connections`)'
     query << " VALUES ('#{name}', '#{password}', #{active}, #{use_ssl}, #{default_hostgroup}, '#{default_schema}', "
-    query << " #{schema_locked}, #{transaction_persistent}, #{fast_forward}, #{backend}, #{frontend}, #{max_connections})"
+    query << " #{schema_locked}, #{transaction_persistent}, #{fast_forward}, "
+    if defined?(backend).nil?
+      query << " #{backend},"
+    end
+    if defined?(frontend).nil?
+      query << " #{frontend},"
+    end
+    query << " #{max_connections})"
     mysql([defaults_file, '-e', query].compact)
     @property_hash[:ensure] = :present
 

--- a/lib/puppet/type/proxy_mysql_user.rb
+++ b/lib/puppet/type/proxy_mysql_user.rb
@@ -80,13 +80,11 @@ Puppet::Type.newtype(:proxy_mysql_user) do
 
   newproperty(:backend) do
     desc 'Backend or not.'
-    defaultto 1
     newvalue(%r{[01]})
   end
 
   newproperty(:frontend) do
     desc 'Frontend or not.'
-    defaultto 1
     newvalue(%r{[01]})
   end
 


### PR DESCRIPTION
let's suppose that you have a proxysql cluster which had 2 nodes configured like this:
```puppet
class { 'proxysql':
     mysql_servers    => [ 
       { 
         'db1' => { 
           'port' => 3306, 
           'hostgroup_id' => 1, 
         } 
       },
       { 
         'db2' => { 
           'hostgroup_id' => 2, 
         } 
       },
     ],
     cluster_name => 'test',
     mysql_users      => [ 
       { 
         'app' => { 
           'password' => '*92C74DFBDA5D60ABD41EFD7EB0DAE389F4646ABB', 
           'default_hostgroup' => 1, 
         } 
       },
       { 
         'ro'  => { 
           'password' => mysql_password('MyReadOnlyUserPassword'), 
           'default_hostgroup' => 2, 
         } 
       },
     ]
}
```
on the first node you will get 
```
Admin> select * from mysql_users;
+----------+-------------------------------------------+--------+---------+-------------------+----------------+---------------+------------------------+--------------+---------+----------+-----------------+
| username | password                                  | active | use_ssl | default_hostgroup | default_schema | schema_locked | transaction_persistent | fast_forward | backend | frontend | max_connections |
+----------+-------------------------------------------+--------+---------+-------------------+----------------+---------------+------------------------+--------------+---------+----------+-----------------+
| app      | *D45AE3CFCDF725E7B8E1AD008208F2B890DE8CA9 | 1      | 0       | 1                 |                | 0             | 0                      | 0            | 1       | 1        | 10000           |
| ro       | *26EBF0470CAD1F87FBF1DD6B3F20F97D7EEC3C42 | 1      | 0       | 2                 |                | 0             | 1                      | 0            | 1       | 1        | 10000           |
+----------+-------------------------------------------+--------+---------+-------------------+----------------+---------------+------------------------+--------------+---------+----------+-----------------+
2 rows in set (0.00 sec)
```
but on the second node users get duplicated - you will have separate users for frontend and backend (see https://github.com/sysown/proxysql/issues/1580)
```
Admin> select * from mysql_users;
+----------+-------------------------------------------+--------+---------+-------------------+----------------+---------------+------------------------+--------------+---------+----------+-----------------+
| username | password                                  | active | use_ssl | default_hostgroup | default_schema | schema_locked | transaction_persistent | fast_forward | backend | frontend | max_connections |
+----------+-------------------------------------------+--------+---------+-------------------+----------------+---------------+------------------------+--------------+---------+----------+-----------------+
| app      | *D45AE3CFCDF725E7B8E1AD008208F2B890DE8CA9 | 1      | 0       | 1                 |                | 0             | 0                      | 0            | 0       | 1        | 10000           |
| ro       | *26EBF0470CAD1F87FBF1DD6B3F20F97D7EEC3C42 | 1      | 0       | 2                 |                | 0             | 1                      | 0            | 0       | 1        | 10000           |
| app      | *D45AE3CFCDF725E7B8E1AD008208F2B890DE8CA9 | 1      | 0       | 1                 |                | 0             | 0                      | 0            | 1       | 0        | 10000           |
| ro       | *26EBF0470CAD1F87FBF1DD6B3F20F97D7EEC3C42 | 1      | 0       | 2                 |                | 0             | 1                      | 0            | 1       | 0        | 10000           |
+----------+-------------------------------------------+--------+---------+-------------------+----------------+---------------+------------------------+--------------+---------+----------+-----------------+
4 rows in set (0.00 sec)
```
if you will now change user configuration on the second node (where you have duplicated users), for example add 
```puppet
     mysql_users      => [ 
       { 
         'app' => { 
           'password' => '*92C74DFBDA5D60ABD41EFD7EB0DAE389F4646ABB', 
           'default_hostgroup' => 1, 
           ' transaction_persistent' => 0
         } 
       },
```

you will get following error:
```
Error: /Stage[main]/Proxysql::Configure/Proxy_mysql_user[app]: Could not evaluate: Execution of '/usr/bin/mysql --defaults-extra-file=/root/.my.cnf -e UPDATE mysql_users SET `frontend` = '1' WHERE username = 'app'' returned 1: ERROR 1045 (#2800) at line 1: UNIQUE constraint failed: mysql_users.username, mysql_users.frontend
Error: /Stage[main]/Proxysql::Configure/Proxy_mysql_user[ro]: Could not evaluate: Execution of '/usr/bin/mysql --defaults-extra-file=/root/.my.cnf -e UPDATE mysql_users SET `transaction_persistent` = '0', `frontend` = '1' WHERE username = 'ro'' returned 1: ERROR 1045 (#2800) at line 1: UNIQUE constraint failed: mysql_users.username, mysql_users.frontend
```

this is becase in Proxysql primary key is not username, but username+backend. And as we have default value for this column defined in proxysql_user resource
```
backend = @resource.value(:backend) || 1
frontend = @resource.value(:frontend) || 1
```
, puppet tries to upgrade each of users to change to defaults values and got constraint violation.

This pull request fixes this issue. It removes default values from frontend and backend columns (because they already have defaults defined in proxysql database), so this value won't be updated every puppet run if it is not explicitly configured.