### PR TITLE
Fix `Proxysql::User` data type to match what's expected by `proxy_mysql_user` resource type

### DIFF
--- a/types/user.pp
+++ b/types/user.pp
@@ -1,13 +1,13 @@
 # lint:ignore:2sp_soft_tabs
 type Proxysql::User = Array[Hash[String, Struct[{ password                         => String[1],
                                                   default_hostgroup                => Integer,
-                                                  Optional[active]                 => Boolean,
-                                                  Optional[use_ssl]                => Boolean,
+                                                  Optional[active]                 => Integer,
+                                                  Optional[use_ssl]                => Integer,
                                                   Optional[default_schema]         => String[1],
-                                                  Optional[schema_locked]          => Boolean,
-                                                  Optional[transaction_persistent] => Boolean,
-                                                  Optional[fast_forward]           => Boolean,
-                                                  Optional[backend]                => Boolean,
-                                                  Optional[frontend]               => Boolean,
+                                                  Optional[schema_locked]          => Integer,
+                                                  Optional[transaction_persistent] => Integer,
+                                                  Optional[fast_forward]           => Integer,
+                                                  Optional[backend]                => Integer,
+                                                  Optional[frontend]               => Integer,
                                                   Optional[max_connections]        => Integer, }],1,1]]
 # lint:endignore                                                   


### PR DESCRIPTION
#### Pull Request (PR) description


#### This Pull Request (PR) fixes the following issues
This PR fixes a Bug, that makes it impossible, to define mysql_user attributes that proxysql expects to be 0 or 1, because the validation Type for those fields was Boolean instead of Integer. But Integer was expected in ruby type definition.
