### PR TITLE
Bugfix: Add missing dependencies

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -27,8 +27,11 @@ class proxysql::install {
       source          => $real_package_source,
       provider        => $proxysql::package_provider,
       install_options => $proxysql::package_install_options,
+      require         => Archive[$real_package_source],
     }
   } else {
+    Exec['apt_update'] -> Package[$proxysql::package_name]
+
     package { $proxysql::package_name:
       ensure          => $proxysql::package_ensure,
       install_options => $proxysql::package_install_options,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -30,7 +30,9 @@ class proxysql::install {
       require         => Archive[$real_package_source],
     }
   } else {
-    Exec['apt_update'] -> Package[$proxysql::package_name]
+    if $facts['os']['family'] == 'Debian' {
+      Exec['apt_update'] -> Package[$proxysql::package_name]
+    }
 
     package { $proxysql::package_name:
       ensure          => $proxysql::package_ensure,


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
This pull request adds missing dependencies related to the installation of `proxysql`.
Specifically, it fixes two problematic situtations: one when `manage_repo` is true and one when `manage_repo` is false.

When `manage_repo` is false, the installation of `proxysql` requires the corresponding Debian archive to exist in the file system.

This is the error I get when Puppet processes resources in the erroneous order.

```
Error: Execution of '/usr/bin/dpkg --force-confold -i /root/proxysql-package.deb' returned 2: dpkg: error: cannot access archive '/root/proxysql-package.deb': No such file or directory
Error: /Stage[main]/Proxysql::Install/Package[proxysql]/ensure: change from purged to present failed: Execution of '/usr/bin/dpkg --force-confold -i /root/proxysql-package.deb' returned 2: dpkg: error: cannot access archive '/root/proxysql-package.deb': No such file or directory
Notice: /Stage[main]/Proxysql::Install/File[proxysql-datadir]/ensure: created
Notice: /Stage[main]/Proxysql::Install/Archive[/root/proxysql-package.deb]/ensure: download archive from https://github.com/sysown/proxysql/releases/download/v1.4.11/proxysql_1.4.11-debian9_amd64.deb to /root/proxysql-package.deb  with cleanup
```

The second case is when the `manage_repo` is true.
Specifically, the `Exec[apt-update]` should always precede the installation of the package in order to retrieve the required information about the newly-added apt repository.

This is the error I get:

```
Error: Execution of '/usr/bin/apt-get -q -y -o DPkg::Options::=--force-confold install proxysql' returned 100: Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package proxysql
Error: /Stage[main]/Proxysql::Install/Package[proxysql]/ensure: change from purged to present failed: Execution of '/usr/bin/apt-get -q -y -o DPkg::Options::=--force-confold install proxysql' returned 100: Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package proxysql
Notice: /Stage[main]/Apt::Update/Exec[apt_update]: Triggered 'refresh' from 1 events
```
