### PR TITLE
Added the ability to forcibly set NULL for fields in settings proxy_mysql_query_rule

### DIFF
--- a/lib/puppet/provider/proxysql.rb
+++ b/lib/puppet/provider/proxysql.rb
@@ -19,6 +19,8 @@ class Puppet::Provider::Proxysql < Puppet::Provider
   def make_sql_value(value)
     if value.nil?
       'NULL'
+    elsif value == 'NULL'
+      'NULL'
     elsif value.is_a? Integer
       value.to_s
     else


### PR DESCRIPTION
#### Pull Request (PR) description
I found not convenient behavior:

Suppose a rule with **digest** has been configured:
```puppet
   proxy_mysql_query_rule { "mysql_query_rule-1":
            rule_id               => 1,
            active                => 1,
            digest                => '0xDBF868B2AA296BC5',
            destination_hostgroup => 2,
            apply                 => 1,
   }
```
It creates in **proxysql** such a rule:
```mysql
Admin> SELECT rule_id,match_pattern,digest FROM mysql_query_rules WHERE rule_id = 1 AND match_pattern IS NULL;
+---------+---------------+--------------------+
| rule_id | match_pattern | digest             |
+---------+---------------+--------------------+
| 1       | NULL          | 0xDBF868B2AA296BC5 |
+---------+---------------+--------------------+
```
**NOTE**: **match_pattern** is real **NULL**
Then I replace **digest** to **match_pattern**:
```puppet
   proxy_mysql_query_rule { "mysql_query_rule-1":
            rule_id               => 1,
            active                => 1,
            match_pattern         => '^SELECT',
            destination_hostgroup => 2,
            apply                 => 1,
   }
```
Then:
```mysql
+---------+---------------+--------------------+
| rule_id | match_pattern | digest             |
+---------+---------------+--------------------+
| 1       | ^SELECT       | 0xDBF868B2AA296BC5 |
+---------+---------------+--------------------+
```
But I would like to have **digest** equal **NULL** =(.

I tried to set **digest** to **undef**:
```puppet
proxy_mysql_query_rule { "mysql_query_rule-1":
    rule_id               => 1,
    active                => 1,
    digest                => undef,
    match_pattern         => '^SELECT',
    destination_hostgroup => 2,
    apply                 => 1,
}
```
Then:
```mysql
Admin> SELECT rule_id,match_pattern,digest FROM mysql_query_rules WHERE rule_id = 1;
+---------+---------------+--------------------+
| rule_id | match_pattern | digest             |
+---------+---------------+--------------------+
| 1       | ^SELECT       | 0xDBF868B2AA296BC5 |
+---------+---------------+--------------------+
1 row in set (0.00 sec)
```
But **digest** not changed =(.

I tried to set **digest** to **NULL**:
```puppet
   proxy_mysql_query_rule { "mysql_query_rule-1":
            rule_id               => 1,
            active                => 1,
            digest                => 'NULL',
            match_pattern         => '^SELECT',
            destination_hostgroup => 2,
            apply                 => 1,
   }
```
Then:
```
Admin> SELECT rule_id,match_pattern,digest FROM mysql_query_rules WHERE rule_id = 1;
+---------+---------------+--------+
| rule_id | match_pattern | digest |
+---------+---------------+--------+
| 1       | ^SELECT       | NULL   |
+---------+---------------+--------+
```
But digest is not real **NULL** =(:
```mysql
Admin> SELECT rule_id,match_pattern,digest FROM mysql_query_rules WHERE rule_id = 1 AND digest IS NULL;
Empty set (0.00 sec)
Admin> 
```
I corrected this behavior with my edit. Now when setting **NULL**, the real **NULL** value is written into the **proxysql**:
```puppet
   proxy_mysql_query_rule { "mysql_query_rule-1":
            rule_id               => 1,
            active                => 1,
            digest                => 'NULL',
            match_pattern         => '^SELECT',
            destination_hostgroup => 2,
            apply                 => 1,
   }
```

```mysql
Admin> SELECT rule_id,match_pattern,digest FROM mysql_query_rules WHERE rule_id = 1 AND digest IS NULL;
+---------+---------------+--------+
| rule_id | match_pattern | digest |
+---------+---------------+--------+
| 1       | ^SELECT       | NULL   |
+---------+---------------+--------+
1 row in set (0.00 sec)

Admin> 
```



#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
