### PR TITLE
readd stdlib module; allow puppetlabs/mysql 8.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -15,6 +15,10 @@
     {
       "name": "puppetlabs-apt",
       "version_requirement": ">= 2.1.0 < 8.0.0"
+    },
+    {
+      "name": "puppetlabs-stdlib",
+      "version_requirement": ">= 5.2.0 < 6.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs-mysql",
-      "version_requirement": ">= 2.5.0 < 8.0.0"
+      "version_requirement": ">= 2.5.0 < 9.0.0"
     },
     {
       "name": "puppetlabs-apt",


### PR DESCRIPTION
https://github.com/voxpupuli/puppet-proxysql/issues/65 see this issue
for details. We had to remove the module because of broken dependencies.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
