### PR TITLE
Fix RedHat yum repo baseurls

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -115,14 +115,14 @@ class proxysql::params {
       $package_dependencies = ['perl-DBI', 'perl-DBD-mysql']
       $repo14             = {
         descr    => 'ProxySQL 1.4.x YUM repository',
-        baseurl  => 'http://repo.proxysql.com/ProxySQL/proxysql-1.4.x/centos/$releasever',
+        baseurl  => "http://repo.proxysql.com/ProxySQL/proxysql-1.4.x/centos/${facts['os']['release']['major']}",
         enabled  => true,
         gpgcheck => true,
         gpgkey   => 'http://repo.proxysql.com/ProxySQL/repo_pub_key',
       }
       $repo20             = {
         descr    => 'ProxySQL 2.0.x YUM repository',
-        baseurl  => 'http://repo.proxysql.com/ProxySQL/proxysql-2.0.x/centos/$releasever',
+        baseurl  => "http://repo.proxysql.com/ProxySQL/proxysql-2.0.x/centos/${facts['os']['release']['major']}",
         enabled  => true,
         gpgcheck => true,
         gpgkey   => 'http://repo.proxysql.com/ProxySQL/repo_pub_key',

--- a/spec/classes/proxysql_spec.rb
+++ b/spec/classes/proxysql_spec.rb
@@ -29,6 +29,10 @@ describe 'proxysql' do
 
           it { is_expected.to contain_class('mysql::client').with(bindings_enable: false) }
 
+          if facts[:osfamily] == 'RedHat'
+            it { is_expected.to contain_yumrepo('proxysql_repo').with_baseurl("http://repo.proxysql.com/ProxySQL/proxysql-1.4.x/centos/#{facts[:operatingsystemmajrelease]}") }
+          end
+
           it do
             is_expected.to contain_package('proxysql').with(ensure: 'installed',
                                                             install_options: [])


### PR DESCRIPTION
On RedHat, `$releasever` is not just the major version number. It is
actually, eg. `7Server`.

There is no repo with baseurl
`http://repo.proxysql.com/ProxySQL/proxysql-1.4.x/centos/7Server`