### PR TITLE
Add `datadir_mode` parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,7 +19,10 @@
 #   The ensure of the ProxySQL service resource. Defaults to 'running'
 #
 # * `datadir`
-#   The directory where ProxySQL will store it's data. defaults to '/var/lib/proxysql'
+#   The directory where ProxySQL will store its data. Defaults to '/var/lib/proxysql'
+#
+# * `datadir_mode`
+#   The filesystem mode for the `datadir`. Defaults to '0600'
 #
 # * `listen_ip`
 #   The ip where the ProxySQL service will listen on. Defaults to '0.0.0.0' aka all configured IP's on the machine
@@ -157,6 +160,7 @@ class proxysql (
   String $service_ensure = $proxysql::params::service_ensure,
 
   String $datadir = $proxysql::params::datadir,
+  Stdlib::Filemode $datadir_mode = $proxysql::params::datadir_mode,
 
   String $listen_ip = $proxysql::params::listen_ip,
   Integer $listen_port = $proxysql::params::listen_port,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -45,7 +45,7 @@ class proxysql::install {
     path   => $proxysql::datadir,
     owner  => $proxysql::sys_owner,
     group  => $proxysql::sys_group,
-    mode   => '0600',
+    mode   => $proxysql::datadir_mode,
   }
 
   class { 'mysql::client':

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,6 +21,7 @@ class proxysql::params {
   $admin_listen_port   = 6032
 
   $datadir = '/var/lib/proxysql'
+  $datadir_mode = '0600'
 
   case $facts['os']['family'] {
     'Debian': {

--- a/spec/classes/proxysql_spec.rb
+++ b/spec/classes/proxysql_spec.rb
@@ -90,6 +90,12 @@ describe 'proxysql' do
             )
           end
         end
+
+        context 'with parameter datadir_mode set' do
+          let(:params) { { 'datadir_mode' => '0644' } }
+
+          it { is_expected.to contain_file('proxysql-datadir').with_mode('0644') }
+        end
       end
     end
   end


### PR DESCRIPTION
By default, the behaviour has not changed, but now you can override the
`datadir` mode with something less restrictive.  This is useful if you
want a non-root user to be able to access proxysql over a unix socket in
the `datadir`.