### PR TITLE
Bugfix: Make classes dependent on the mysql package

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -53,4 +53,10 @@ class proxysql::install {
     bindings_enable => false,
   }
 
+  Class['mysql::client::install']
+  -> Class['proxysql::admin_credentials']
+
+  Class['mysql::client::install']
+  -> Class['proxysql::reload_config']
+
 }

--- a/spec/classes/proxysql_spec.rb
+++ b/spec/classes/proxysql_spec.rb
@@ -19,7 +19,9 @@ describe 'proxysql' do
           it { is_expected.to contain_class('proxysql::config').that_comes_before('Class[proxysql::service]') }
           it { is_expected.to contain_class('proxysql::service').that_comes_before('Class[proxysql::admin_credentials]') }
           it { is_expected.to contain_class('proxysql::admin_credentials').that_comes_before('Class[proxysql::reload_config]') }
+          it { is_expected.to contain_class('proxysql::admin_credentials').that_requires('Class[mysql::client::install]') }
           it { is_expected.to contain_class('proxysql::reload_config').that_comes_before('Class[proxysql::configure]') }
+          it { is_expected.to contain_class('proxysql::reload_config').that_requires('Class[mysql::client::install]') }
           it { is_expected.to contain_class('proxysql::configure').that_comes_before('Anchor[proxysql::end]') }
 
           it { is_expected.to contain_anchor('proxysql::end') }


### PR DESCRIPTION
This commit fixes the issue where the classes `reload_config` and `admin_credentials` are not dependent on the installation of the `mysql-client` package, even though the corresponding classes issue `exec` commands through the `usr/bin/mysql`.

This is the snapshot that confirms that for example, the `Exec[reload-config]` can be applied before the installation of the `mysql-client`.

```
Notice: Compiled catalog for ee8de30b8bef in environment production in 0.49 seconds
Notice: /Stage[main]/Proxysql::Repo/Apt::Source[proxysql_repo]/Apt::Key[Add key: 1448BF693CA600C799EB935804A562FB79953B49 from Apt::Source proxysql_repo]/Apt_key[Add key: 1448BF693CA600C799EB935804A562FB79953B49 from Apt::Source proxysql_repo]/ensure: created
Notice: /Stage[main]/Proxysql::Repo/Apt::Source[proxysql_repo]/Apt::Setting[list-proxysql_repo]/File[/etc/apt/sources.list.d/proxysql_repo.list]/ensure: defined content as '{md5}ec8b33e9bd82f97f130884440f3e05d4'
Notice: /Stage[main]/Apt::Update/Exec[apt_update]: Triggered 'refresh' from 1 events
Notice: /Stage[main]/Proxysql::Install/File[proxysql-datadir]/ensure: created
Notice: /Stage[main]/Proxysql::Install/Package[proxysql]/ensure: created
Notice: /Stage[main]/Proxysql::Config/File[proxysql-config-file]/content: content changed '{md5}e2bbf9a04697db9076e499d457777578' to '{md5}e2c8ad609400497f87fdf1afa1e7becd'
Notice: /Stage[main]/Proxysql::Config/File[proxysql-config-file]/mode: mode changed '0600' to '0640'
Notice: /Stage[main]/Proxysql::Service/Service[proxysql]/ensure: ensure changed 'stopped' to 'running'
Notice: /Stage[main]/Proxysql::Service/Exec[wait_for_admin_socket_to_open]/returns: executed successfully
Notice: /Stage[main]/Proxysql::Service/Exec[wait_for_admin_socket_to_open]: Triggered 'refresh' from 1 events
Notice: /Stage[main]/Proxysql::Admin_credentials/File[root-mycnf-file]/ensure: defined content as '{md5}3385c8f6fe71f2952b1b3bfe45c20daf'
Error: /Stage[main]/Proxysql::Reload_config/Exec[reload-config]: Failed to call refresh: Could not find command '/usr/bin/mysql'
Error: /Stage[main]/Proxysql::Reload_config/Exec[reload-config]: Could not find command '/usr/bin/mysql'
Notice: /Stage[main]/Mysql::Client::Install/Package[mysql_client]/ensure: created
Notice: Applied catalog in 37.39 seconds
```

Inside the `init.pp` file of the `mysql` module, indeed, the class `mysql::client::install` is included (See [here](https://github.com/puppetlabs/puppetlabs-mysql/blob/fb4aa1d984c68f0c4fb68401970ff5f4ef10bb68/manifests/client.pp#L30). However, Puppet does not impose any ordering constraint between the included class (i.e., `mysql::client::install`) and the class that invokes the parent module (e.g., `proxysql::admin_credentials`).

For more details, see a useful [blog](https://puppet.com/blog/class-containment-puppet).