### PR TITLE
Replace `repo_version` with `version`, default to installing ProxySQL 2 and fix `restart => true`

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,8 +1,9 @@
 fixtures:
   repositories:
-    stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
-    mysql: "git://github.com/puppetlabs/puppetlabs-mysql.git"
-    apt: "git://github.com/puppetlabs/puppetlabs-apt.git"
+    stdlib: 'https://github.com/puppetlabs/puppetlabs-stdlib.git'
+    mysql: 'https://github.com/puppetlabs/puppetlabs-mysql.git'
+    apt: 'https://github.com/puppetlabs/puppetlabs-apt.git'
+    systemd: 'https://github.com/camptocamp/puppet-systemd.git'
     yumrepo_core:
       repo: https://github.com/puppetlabs/puppetlabs-yumrepo_core.git
       puppet_version: ">= 6.0.0"

--- a/README.markdown
+++ b/README.markdown
@@ -24,11 +24,15 @@ This module will install the ProxySQL and manage it's configuration. It also ext
 
 ## Setup
 
-### Setup Requirements **OPTIONAL**
+### Setup Requirements
 
-The module requires Puppet 5.5.8 over above.
+The module requires Puppet 5.5.8 and above. It also depends on:
+* [puppetlabs/mysql](https://forge.puppet.com/puppetlabs/mysql)
+* [puppetlabs/apt](https://forge.puppet.com/puppetlabs/apt) - (Not strictly required on non Debian based systems)
+* [puppetlabs/stdlib](https://forge.puppet.com/puppetlabs/stdlib)
+* [camptocamp/systemd](https://forge.puppet.com/camptocamp/systemd) - (Not strictly required if installing ProxySQL 1.4)
 
-It depends on the [puppetlabs](https://puppet.com/)/[mysql](https://github.com/puppetlabs/puppetlabs-mysql) module (>= 2.5.x) and on the [puppetlabs](https://puppet.com/)/[apt](https://github.com/puppetlabs/puppetlabs-apt) module (>= 2.1.x) when using deb based systems.
+For up to date details on external dependencies, please see the [metadata.json](https://github.com/voxpupuli/puppet-proxysql/blob/master/metadata.json) or for released versions, the [puppet forge page](https://forge.puppet.com/puppet/proxysql/dependencies).
 
 ### Beginning with proxysql
 

--- a/README.markdown
+++ b/README.markdown
@@ -38,7 +38,16 @@ include proxysql
 ```
 
 By default, packages come from the official upstream package repositories which the module will configure.
-Most operating systems currently default to 1.4.x packages, but this can be changed with the `repo_version` parameter.
+On new installations, (by default), the 2.0.x repository will be configured. If ProxySQL is already installed, then the repository matching the currently installed version
+will be used.
+
+To force the use of 1.4.x packages, use the `version` parameter.  (Note, the example below does not force the installation of `1.4.16`, it only ensures the correct repository
+is configured and that ProxySQL will be configured as if the version installed is `1.4.16`)
+```puppet
+class { 'proxysql':
+  version => '1.4.16',
+}
+```
 
 To use your Operating System's own packages set `manage_repo => false`.
 ```puppet
@@ -372,8 +381,11 @@ Specifies whether the managed ProxySQL resources should be immediately save to d
 ##### `manage_repo`
 Determines whether this module will manage the repositories where ProxySQL might be. Defaults to 'true'
 
-#### `repo_version`
-Specifies the repo version. Possible values are '1.4.x' and '2.0.x'. String, defaults to '1.4.x' ('2.0.x' for Ubuntu 18.04).
+##### `version`
+The version of proxysql being managed.  This parameter affects the repository configured when `manage_repo == true` and how the service is managed.
+It does not affect the package version being installed.  It is used as a hint to the puppet module on how to configure proxysql. To control the exact version
+deployed, use `package_name` or `package_source`.  Defaults to the version currently installed, or `2.0.7` if the `proxysql_version` fact is not yet
+available.
 
 ##### `package_source`
 location of a proxysql package.  When specified, this package will be installed with the `package\_provider` and the `manage_repo` setting will be ignored.
@@ -383,10 +395,10 @@ Since version 4 of this module, this defaults to `undef` and needs to be specifi
 provider for `package_source`. Defaults to `dpkg` for debian-based, and `rpm` for redhat systems.
 
 ##### `sys_owner`
-owner of the datadir and config_file, defaults to 'root'
+owner of the datadir and config_file, defaults to `root` or `proxysql` depending on `version`.
 
 ##### `sys_group`
-group of the datadir and config_file, defaults to 'root'
+owner of the datadir and config_file, defaults to the value of `sys_owner`.
 
 ##### `override_config_settings`
 Which configuration variables should be overriden. Hash, defaults to `{}` (empty hash).

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -29,10 +29,6 @@ class proxysql::params {
       $package_dependencies = []
 
       if $facts['os']['release']['major'] == '18.04' {
-        $_repo_version = '2.0.x'
-        $_sys_owner   = 'proxysql'
-        $_sys_group   = 'proxysql'
-
         # The 2.0.x systemd service file in ubuntu 18.04 has `ReadWritePaths=/var/lib/proxysql /var/run/proxysql`.
         # This limits where we can write sockets.
         $_listen_socket = "${datadir}/proxysql.sock"
@@ -83,9 +79,13 @@ class proxysql::params {
     }
   }
 
-  $sys_owner = pick(getvar('_sys_owner'),'root')
-  $sys_group = pick(getvar('_sys_group'),'root')
-  $repo_version = pick(getvar('_repo_version'),'1.4.x')
+  if fact('proxysql_version') {
+    $short_proxysql_version_fact = regsubst(fact('proxysql_version'),'^(\\d+\\.\\d+\\.\\d+)','\\1')
+  } else {
+    $short_proxysql_version_fact = undef
+  }
+  $version = pick($short_proxysql_version_fact,'2.0.7')
+
   $listen_socket = pick(getvar('_listen_socket'),'/tmp/proxysql.sock')
   $admin_listen_socket = pick(getvar('_admin_listen_socket'),'/tmp/proxysql_admin.sock')
 

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -7,9 +7,10 @@ class proxysql::repo {
   assert_private()
 
   if $proxysql::manage_repo and !$proxysql::package_source {
-    $repo = $proxysql::repo_version ? {
-      '2.0.x' => $proxysql::params::repo20,
-      '1.4.x' => $proxysql::params::repo14,
+    $repo = $proxysql::version ? {
+      /^2\.0\./ => $proxysql::params::repo20,
+      /^1\.4\./ => $proxysql::params::repo14,
+      default   => fail("Unsupported `proxysql::version` ${proxysql::version}")
     }
     case $facts['os']['family'] {
       'Debian': {

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -5,12 +5,6 @@
 #
 class proxysql::service {
 
-  if $proxysql::manage_config_file {
-    $service_require = File['proxysql-config-file']
-  } else {
-    $service_require = undef
-  }
-
   if $proxysql::restart {
     service { $proxysql::service_name:
       ensure     => $proxysql::service_ensure,
@@ -21,7 +15,6 @@ class proxysql::service {
       status     => '/etc/init.d/proxysql status',
       start      => '/usr/bin/proxysql --reload',
       stop       => '/etc/init.d/proxysql stop',
-      require    => $service_require,
     }
   } else {
     service { $proxysql::service_name:
@@ -29,7 +22,6 @@ class proxysql::service {
       enable     => true,
       hasstatus  => true,
       hasrestart => true,
-      require    => $service_require,
     }
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -19,6 +19,10 @@
     {
       "name": "puppetlabs-stdlib",
       "version_requirement": ">= 5.2.0 < 7.0.0"
+    },
+    {
+      "name": "camptocamp-systemd",
+      "version_requirement": ">= 1.1.0 < 3.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -1,16 +1,51 @@
 require 'spec_helper_acceptance'
 
 describe 'proxysql class' do
-  context 'default parameters' do
-    # Using puppet_apply as a helper
+  unless fact('os.release.major') == '18.04' # There are no proxysql 1.4 packages for bionic
+    context 'version 1.4' do
+      it 'works idempotently with no errors' do
+        pp = <<-EOS
+      class { 'proxysql':
+        version => '1.4.16',
+      }
+        EOS
+
+        # Run it twice and test for idempotency
+        apply_manifest(pp, catch_failures: true)
+        apply_manifest(pp, catch_changes: true)
+      end
+
+      describe package('proxysql') do
+        it { is_expected.to be_installed }
+      end
+
+      describe service('proxysql') do
+        it { is_expected.to be_enabled }
+        it { is_expected.to be_running }
+      end
+
+      describe command('proxysql --version') do
+        its(:exit_status) { is_expected.to eq 0 }
+        its(:stderr) { is_expected.to match %r{^ProxySQL version 1\.4\.} }
+      end
+    end
+  end
+
+  context 'Upgrading to version 2.0' do
     it 'works idempotently with no errors' do
       pp = <<-EOS
-      class { 'proxysql': }
+      class { 'proxysql':
+        package_ensure => latest,
+        version        => '2.0.7',
+      }
       EOS
 
       # Run it twice and test for idempotency
       apply_manifest(pp, catch_failures: true)
       apply_manifest(pp, catch_changes: true)
+
+      # Run it again, this time relying on proxysql_version fact
+      apply_manifest('class { \'proxysql\':}', catch_changes: true)
     end
 
     describe package('proxysql') do
@@ -22,16 +57,9 @@ describe 'proxysql class' do
       it { is_expected.to be_running }
     end
 
-    if fact('os.release.major') == '18.04'
-      describe command('proxysql --version') do
-        its(:exit_status) { is_expected.to eq 0 }
-        its(:stdout) { is_expected.to match %r{^ProxySQL version 2\.0\.} }
-      end
-    else
-      describe command('proxysql --version') do
-        its(:exit_status) { is_expected.to eq 0 }
-        its(:stderr) { is_expected.to match %r{ProxySQL version} }
-      end
+    describe command('proxysql --version') do
+      its(:exit_status) { is_expected.to eq 0 }
+      its(:stdout) { is_expected.to match %r{^ProxySQL version 2\.0\.} }
     end
   end
 

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -320,4 +320,28 @@ describe 'proxysql class' do
       its(:stdout) { is_expected.to match '^\^SELECT$' }
     end
   end
+  context 'with restart => true' do
+    it 'works idempotently with no errors' do
+      pp = <<-EOS
+      class { 'proxysql':
+        restart                  => true,
+        listen_port              => 3306,
+        admin_username           => 'admin',
+        admin_password           => Sensitive('654321'),
+        monitor_username         => 'monitor',
+        monitor_password         => Sensitive('123456'),
+        override_config_settings => {
+          mysql_variables => {
+            'monitor_writer_is_also_reader' => true,
+          }
+        },
+      }
+      EOS
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+    end
+    describe service('proxysql') do
+      it { is_expected.to be_running }
+    end
+  end
 end

--- a/spec/classes/proxysql_spec.rb
+++ b/spec/classes/proxysql_spec.rb
@@ -32,7 +32,7 @@ describe 'proxysql' do
           it { is_expected.to contain_class('mysql::client').with(bindings_enable: false) }
 
           if facts[:osfamily] == 'RedHat'
-            it { is_expected.to contain_yumrepo('proxysql_repo').with_baseurl("http://repo.proxysql.com/ProxySQL/proxysql-1.4.x/centos/#{facts[:operatingsystemmajrelease]}") }
+            it { is_expected.to contain_yumrepo('proxysql_repo').with_baseurl("http://repo.proxysql.com/ProxySQL/proxysql-2.0.x/centos/#{facts[:operatingsystemmajrelease]}") }
           end
 
           it do
@@ -40,15 +40,14 @@ describe 'proxysql' do
                                                             install_options: [])
           end
 
-          if facts[:operatingsystemrelease] == '18.04'
-            sys_user = 'proxysql'
-            sys_group = 'proxysql'
-            admin_socket = '/var/lib/proxysql/proxysql_admin.sock'
-          else
-            sys_user = 'root'
-            sys_group = 'root'
-            admin_socket = '/tmp/proxysql_admin.sock'
-          end
+          sys_user = 'proxysql'
+          sys_group = 'proxysql'
+
+          admin_socket = if facts[:operatingsystemrelease] == '18.04'
+                           '/var/lib/proxysql/proxysql_admin.sock'
+                         else
+                           '/tmp/proxysql_admin.sock'
+                         end
 
           it do
             is_expected.to contain_file('proxysql-config-file').with(ensure: 'file',

--- a/spec/classes/proxysql_spec.rb
+++ b/spec/classes/proxysql_spec.rb
@@ -75,9 +75,14 @@ describe 'proxysql' do
 
           it do
             is_expected.to contain_service('proxysql').with(ensure: 'running',
-                                                            enable: true,
-                                                            hasstatus: true,
-                                                            hasrestart: true)
+                                                            enable: true)
+          end
+
+          unless (facts[:osfamily] == 'RedHat' && facts[:operatingsystemmajrelease] == '7') ||
+                 (facts[:operatingsystem] == 'Ubuntu' && facts[:operatingsystemmajrelease] == '18.04') ||
+                 (facts[:operatingsystem] == 'Debian' && facts[:operatingsystemmajrelease] == '9')
+            it { is_expected.to contain_service('proxysql').with_hasstatus(true) }
+            it { is_expected.to contain_service('proxysql').with_hasrestart(true) }
           end
 
           it do


### PR DESCRIPTION
* Install version 2.0.x by default
    
    This is a breaking change that replaces the `repo_version` parameter
    with a `version` parameter.  `version` is used to configure the correct
    repository and can also be used to correctly configure the service (eg
    later versions use systemd on CentOS).
    
    `version` can be set manually, but otherwise defaults to the currently
    installed version, (if the fact is available), or `2.0.7` otherwise.

* Support `restart == true` with ProxySQL 2

  When using packages that use systemd, and `restart == true`, a systemd
  drop-in file is created to add the `--reload` flag to the start command.
  Previously, the module assumed init.d only and the `start` parameter of
  the Service resource started ProxySQL manually.  This resulted in the
  Pidfile not being written and the systemd service reporting an incorrect
  status.

  camptocamp/systemd is a new dependency required on modern OSes with
  latest ProxySQL.
    
  Fixes #115