### PR TITLE
Add `proxysql_runtime` fact

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -800,9 +800,30 @@ The 5th argument for the scheduler script to run. Optional, defaults to NULL.
 ##### `comment`
 Optional comment.
 
+### `proxysql\_runtime` fact
+
+This module ships a fact that you may find useful in your profiles.  It is not used by the module itself.
+The `proxysql_runtime` fact queries ProxySQL and returns a hash containing the contents of several of the [runtime tables](https://github.com/sysown/proxysql/wiki/Main-(runtime)).
+
+The fact will only return data if the [mysql2](https://rubygems.org/gems/mysql2) library is installed in your puppet agent's gem environment.
+
+For systems using official puppet packages, (All In One packages), the following code can be used to install this gem and make the fact
+available.
+```puppet
+$dev_packages = ['mariadb-devel','make','gcc']
+ensure_packages($dev_packages)
+
+package { 'mysql2 gem':
+  ensure   => present,
+  name     => 'mysql',
+  provider => 'puppet_gem',
+  require  => Package[$dev_packages],
+}
+```
+
 ## Limitations
 
-The module requires Puppet 5.5 or above.
+The module requires Puppet 5.5 or above. The `proxysql_runtime` fact only works when using the default value for `mycnf_file_name`.
 
 ## Development
 

--- a/lib/facter/proxysql_runtime.rb
+++ b/lib/facter/proxysql_runtime.rb
@@ -1,0 +1,41 @@
+Facter.add(:proxysql_runtime) do
+  client = nil
+
+  confine :proxysql_version do |version|
+    version =~ %r{^2}
+  end
+
+  confine do
+    begin
+      require 'mysql2'
+    rescue LoadError
+      next
+    end
+
+    begin
+      client = Mysql2::Client.new(default_file: '/root/.my.cnf')
+    rescue Mysql2::Error::ConnectionError => e
+      Facter.debug(e.inspect)
+    end
+    client
+  end
+
+  setcode do
+    fact = {}
+    [
+      # tables that might include unencrypted credentials have not been included here.
+      'runtime_mysql_servers',
+      'runtime_mysql_aws_aurora_hostgroups',
+      'runtime_mysql_galera_hostgroups',
+      'runtime_mysql_group_replication_hostgroups',
+      'runtime_mysql_query_rules',
+      'runtime_mysql_query_rules_fast_routing',
+      'runtime_mysql_replication_hostgroups',
+      'runtime_proxysql_servers'
+    ].each do |table|
+      results = client.query("SELECT * FROM #{table}")
+      fact[table] = results.map { |row| row }
+    end
+    fact
+  end
+end


### PR DESCRIPTION
Returns a hash of containing ProxySQL runtime tables.
Requires `mysql2` gem in puppet environment.