### PR TITLE
Add debian 10 support

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -9,3 +9,4 @@
     - set: centos7-64
     - set: debian8-64
     - set: debian9-64
+    - set: debian10-64

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,6 +79,14 @@ matrix:
     bundler_args: --without development release
     env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=debian9-64 BEAKER_HYPERVISOR=docker CHECK=beaker
     services: docker
+  - rvm: 2.5.3
+    bundler_args: --without development release
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=debian10-64 BEAKER_HYPERVISOR=docker CHECK=beaker
+    services: docker
+  - rvm: 2.5.3
+    bundler_args: --without development release
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=debian10-64 BEAKER_HYPERVISOR=docker CHECK=beaker
+    services: docker
 branches:
   only:
   - master

--- a/metadata.json
+++ b/metadata.json
@@ -64,7 +64,8 @@
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
         "8",
-        "9"
+        "9",
+        "10"
       ]
     },
     {

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -1,7 +1,8 @@
 require 'spec_helper_acceptance'
 
 describe 'proxysql class' do
-  unless fact('os.release.major') == '18.04' # There are no proxysql 1.4 packages for bionic
+  unless fact('os.release.major') == '18.04' ||
+         (fact('os.name') == 'Debian' && fact('os.release.major') == '10') # There are no proxysql 1.4 packages for these OSes
     context 'version 1.4' do
       it 'works idempotently with no errors' do
         pp = <<-EOS

--- a/spec/classes/proxysql_spec.rb
+++ b/spec/classes/proxysql_spec.rb
@@ -80,7 +80,7 @@ describe 'proxysql' do
 
           unless (facts[:osfamily] == 'RedHat' && facts[:operatingsystemmajrelease] == '7') ||
                  (facts[:operatingsystem] == 'Ubuntu' && facts[:operatingsystemmajrelease] == '18.04') ||
-                 (facts[:operatingsystem] == 'Debian' && facts[:operatingsystemmajrelease] == '9')
+                 (facts[:operatingsystem] == 'Debian' && facts[:operatingsystemmajrelease] =~ %r{^(9|10)$})
             it { is_expected.to contain_service('proxysql').with_hasstatus(true) }
             it { is_expected.to contain_service('proxysql').with_hasrestart(true) }
           end


### PR DESCRIPTION
Packages for `buster` were released with ProxySQL 2.0.7