### PR TITLE
Replace `anchor` pattern with `contain`

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -248,24 +248,31 @@ class proxysql (
       },
     }
   } else {
-      $settings_cluster = undef
-    }
+    $settings_cluster = undef
+  }
 
   $settings_result = deep_merge($settings, $settings_cluster)
 
   $config_settings = deep_merge($proxysql::params::config_settings, $settings_result, $override_config_settings)
   # lint:endignore
 
-  anchor { 'proxysql::begin': }
-  -> class { 'proxysql::prerequisites':}
-  -> class { 'proxysql::repo':}
-  -> class { 'proxysql::install':}
-  -> class { 'proxysql::config':}
-  -> class { 'proxysql::service':}
-  -> class { 'proxysql::admin_credentials':}
-  -> class { 'proxysql::reload_config':}
-  -> class { 'proxysql::configure':}
-  -> anchor { 'proxysql::end': }
+  contain proxysql::prerequisites
+  contain proxysql::repo
+  contain proxysql::install
+  contain proxysql::config
+  contain proxysql::service
+  contain proxysql::admin_credentials
+  contain proxysql::reload_config
+  contain proxysql::configure
+
+  Class['proxysql::prerequisites']
+  -> Class['proxysql::repo']
+  -> Class['proxysql::install']
+  -> Class['proxysql::config']
+  -> Class['proxysql::service']
+  -> Class['proxysql::admin_credentials']
+  -> Class['proxysql::reload_config']
+  -> Class['proxysql::configure']
 
   Class['proxysql::install']
   ~> Class['proxysql::service']

--- a/spec/classes/proxysql_spec.rb
+++ b/spec/classes/proxysql_spec.rb
@@ -13,7 +13,7 @@ describe 'proxysql' do
           it { is_expected.to compile.with_all_deps }
 
           it { is_expected.to contain_class('proxysql::params') }
-          it { is_expected.to contain_anchor('proxysql::begin').that_comes_before('Class[proxysql::repo]') }
+          it { is_expected.to contain_class('proxysql::prerequisites').that_comes_before('Class[proxysql::repo]') }
           it { is_expected.to contain_class('proxysql::repo').that_comes_before('Class[proxysql::install]') }
           it { is_expected.to contain_class('proxysql::install').that_comes_before('Class[proxysql::config]') }
           it { is_expected.to contain_class('proxysql::config').that_comes_before('Class[proxysql::service]') }
@@ -22,9 +22,7 @@ describe 'proxysql' do
           it { is_expected.to contain_class('proxysql::admin_credentials').that_requires('Class[mysql::client::install]') }
           it { is_expected.to contain_class('proxysql::reload_config').that_comes_before('Class[proxysql::configure]') }
           it { is_expected.to contain_class('proxysql::reload_config').that_requires('Class[mysql::client::install]') }
-          it { is_expected.to contain_class('proxysql::configure').that_comes_before('Anchor[proxysql::end]') }
-
-          it { is_expected.to contain_anchor('proxysql::end') }
+          it { is_expected.to contain_class('proxysql::configure') }
 
           it { is_expected.to contain_class('proxysql::install').that_notifies('Class[proxysql::service]') }
           it { is_expected.to contain_class('proxysql::service').that_subscribes_to('Class[proxysql::install]') }


### PR DESCRIPTION
`contain` has been available and preferred since puppet 3.4?? IIRC.