### PR TITLE
Manage SELinux rules to allow logrotate to work

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,6 +4,11 @@ fixtures:
     mysql: 'https://github.com/puppetlabs/puppetlabs-mysql.git'
     apt: 'https://github.com/puppetlabs/puppetlabs-apt.git'
     systemd: 'https://github.com/camptocamp/puppet-systemd.git'
+    selinux: 'https://github.com/voxpupuli/puppet-selinux.git'
+    extlib: 'https://github.com/voxpupuli/puppet-extlib.git'
     yumrepo_core:
       repo: https://github.com/puppetlabs/puppetlabs-yumrepo_core.git
+      puppet_version: ">= 6.0.0"
+    selinux_core:
+      repo: https://github.com/puppetlabs/puppetlabs-selinux_core.git
       puppet_version: ">= 6.0.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: bionic
 language: ruby
 cache: bundler
 before_install:
-  - gem update --system
+  - yes | gem update --system
   - gem update bundler
   - bundle --version
 script:

--- a/README.markdown
+++ b/README.markdown
@@ -34,6 +34,8 @@ The module requires Puppet 5.5.8 and above. It also depends on:
 
 For up to date details on external dependencies, please see the [metadata.json](https://github.com/voxpupuli/puppet-proxysql/blob/master/metadata.json) or for released versions, the [puppet forge page](https://forge.puppet.com/puppet/proxysql/dependencies).
 
+[puppet/selinux](https://forge.puppet.com/puppet/selinux) is an optional `soft` dependency and not even listed in the [metadata.json](https://github.com/voxpupuli/puppet-proxysql/blob/master/metadata.json).  No Operating Systems *require* this module to be present, but if it is, it will be used to install SELinux rules that allow logrotate to work.  See [manage\_selinux](#manage_selinux)
+
 ### Beginning with proxysql
 
 To install the ProxySQL software with all the default options:
@@ -328,6 +330,10 @@ The ensure of the ProxySQL service resource. Defaults to 'running'
 
 ##### `datadir`
 The directory where ProxySQL will store it's data. defaults to '/var/lib/proxysql'
+
+##### `manage_selinux`
+Whether to create the required selinux rules for logrotate to work.  Defaults to `true`, but is only applicable to systems where SELinux is active (`enforcing` or `permissive`).
+This parameter also requires the [puppet/selinux](https://forge.puppet.com/puppet/selinux) module to be installed.
 
 ##### `listen_ip`
 The ip where the ProxySQL service will listen on. Defaults to '0.0.0.0' aka all configured IP's on the machine

--- a/manifests/selinux.pp
+++ b/manifests/selinux.pp
@@ -1,0 +1,22 @@
+# @summary Adds selinux configuration needed for logrotate to work
+#
+# @api private
+class proxysql::selinux {
+  $content_te = @(POLICY)
+  module puppet-proxysql 1.0;
+
+  require {
+          class file read;
+  }
+  | POLICY
+  selinux::module { 'puppet-proxysql':
+    ensure     => present,
+    content_fc => "${proxysql::datadir}/proxysql.log* gen_context(system_u:object_r:var_log_t,s0)\n",
+    content_te => $content_te,
+    builder    => 'refpolicy',
+  }
+  selinux::exec_restorecon { $proxysql::datadir:
+    subscribe => Selinux::Module['puppet-proxysql'],
+    require   => File['proxysql-datadir'],
+  }
+}

--- a/metadata.json
+++ b/metadata.json
@@ -21,6 +21,10 @@
       "version_requirement": ">= 5.2.0 < 7.0.0"
     },
     {
+      "name": "puppet-extlib",
+      "version_requirement": ">= 2.1.0 < 5.0.0"
+    },
+    {
       "name": "camptocamp-systemd",
       "version_requirement": ">= 1.1.0 < 3.0.0"
     }

--- a/spec/classes/proxysql_spec.rb
+++ b/spec/classes/proxysql_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'deep_merge'
 
 describe 'proxysql' do
   context 'supported operating systems' do
@@ -99,6 +100,27 @@ describe 'proxysql' do
           let(:params) { { 'datadir_mode' => '0644' } }
 
           it { is_expected.to contain_file('proxysql-datadir').with_mode('0644') }
+        end
+
+        if facts[:osfamily] == 'RedHat'
+          describe 'manage_selinux' do
+            context 'on systems with selinux enabled' do
+              let(:facts) do
+                facts.deep_merge(
+                  os: { selinux: { current_mode: 'enforcing' } }
+                )
+              end
+
+              context 'by default' do
+                it { is_expected.to contain_class('proxysql::selinux') }
+              end
+              context 'when manage_selinux is `false`' do
+                let(:params) { { 'manage_selinux' => false } }
+
+                it { is_expected.not_to contain_class('proxysql::selinux') }
+              end
+            end
+          end
         end
       end
     end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -13,5 +13,8 @@ RSpec.configure do |c|
   c.before :suite do
     install_module
     install_module_dependencies
+    hosts.each do |host|
+      on host, puppet('module', 'install', 'puppet/selinux')
+    end
   end
 end


### PR DESCRIPTION
The proxysql.log is created under the datadir and this means by default it doesn't have an SELinux context that will allow logrotate to rotate it.  This PR adds suitable rules.

See https://github.com/sysown/proxysql/issues/1177