### PR TITLE
Avoid reloading proxysql 2 as root

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -28,6 +28,13 @@ class proxysql::service {
     }
   } else {
     if $proxysql::restart {
+      if versioncmp($proxysql::version, '2') >= 0 and fact('os.family') == 'RedHat' {
+        # In proxysql version 2, the init.d scripts, (EL6 and EL7 with proxysql < 2.0.7) support a `reload` option.
+        # Use this instead of `/usr/bin/proxysql --reload`, (which will run as root).
+        $start = '/etc/init.d/proxysql reload'
+      } else {
+        $start = '/usr/bin/proxysql --reload'
+      }
       service { $proxysql::service_name:
         ensure     => $proxysql::service_ensure,
         enable     => true,
@@ -35,7 +42,7 @@ class proxysql::service {
         hasrestart => false,
         provider   => 'base',
         status     => '/etc/init.d/proxysql status',
-        start      => '/usr/bin/proxysql --reload',
+        start      => $start,
         stop       => '/etc/init.d/proxysql stop',
       }
     } else {

--- a/spec/classes/proxysql_spec.rb
+++ b/spec/classes/proxysql_spec.rb
@@ -79,6 +79,21 @@ describe 'proxysql' do
                                                             enable: true)
           end
 
+          if facts[:osfamily] == 'RedHat'
+            context 'with restart = true' do
+              context 'and proxysql 1.4.16' do
+                let(:params) { { 'restart' => true, 'version' => '1.4.16' } }
+
+                it { is_expected.to contain_service('proxysql').with_start('/usr/bin/proxysql --reload') }
+              end
+              context 'and proxysql 2.0.6' do
+                let(:params) { { 'restart' => true, 'version' => '2.0.6' } }
+
+                it { is_expected.to contain_service('proxysql').with_start('/etc/init.d/proxysql reload') }
+              end
+            end
+          end
+
           unless (facts[:osfamily] == 'RedHat' && facts[:operatingsystemmajrelease] == '7') ||
                  (facts[:operatingsystem] == 'Ubuntu' && facts[:operatingsystemmajrelease] == '18.04') ||
                  (facts[:operatingsystem] == 'Debian' && facts[:operatingsystemmajrelease] =~ %r{^(9|10)$})


### PR DESCRIPTION
On EL6/7 the init.d script has a `reload` option.  This should be used
instead of running `/usr/bin/proxysql --reload` as root.

This applies to EL6 with all versions of proxysql 2 and EL7 when using
proxysql >= 2 and < 2.0.7

Fixes #134