### PR TITLE
Use distinct names for yum repos

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -60,6 +60,7 @@ class proxysql::params {
       $package_provider = 'rpm'
       $package_dependencies = ['perl-DBI', 'perl-DBD-mysql']
       $repo14             = {
+        name     => 'proxysql_1_4',
         descr    => 'ProxySQL 1.4.x YUM repository',
         baseurl  => "http://repo.proxysql.com/ProxySQL/proxysql-1.4.x/centos/${facts['os']['release']['major']}",
         enabled  => true,
@@ -67,6 +68,7 @@ class proxysql::params {
         gpgkey   => 'http://repo.proxysql.com/ProxySQL/repo_pub_key',
       }
       $repo20             = {
+        name     => 'proxysql_2_0',
         descr    => 'ProxySQL 2.0.x YUM repository',
         baseurl  => "http://repo.proxysql.com/ProxySQL/proxysql-2.0.x/centos/${facts['os']['release']['major']}",
         enabled  => true,

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -20,8 +20,16 @@ class proxysql::repo {
         Class['apt::update'] -> Package[$proxysql::package_name]
       }
       'RedHat': {
-        yumrepo { 'proxysql_repo':
+        yumrepo { $repo['name']:
           * => $repo,
+        }
+
+        $purge_repo = $proxysql::version ? {
+          /^2\.0\./ => $proxysql::params::repo14['name'],
+          /^1\.4\./ => $proxysql::params::repo20['name'],
+        }
+        yumrepo { ['proxysql_repo', $purge_repo]:
+          ensure => absent,
         }
       }
       default: {

--- a/spec/classes/proxysql_spec.rb
+++ b/spec/classes/proxysql_spec.rb
@@ -31,7 +31,9 @@ describe 'proxysql' do
           it { is_expected.to contain_class('mysql::client').with(bindings_enable: false) }
 
           if facts[:osfamily] == 'RedHat'
-            it { is_expected.to contain_yumrepo('proxysql_repo').with_baseurl("http://repo.proxysql.com/ProxySQL/proxysql-2.0.x/centos/#{facts[:operatingsystemmajrelease]}") }
+            it { is_expected.to contain_yumrepo('proxysql_2_0').with_baseurl("http://repo.proxysql.com/ProxySQL/proxysql-2.0.x/centos/#{facts[:operatingsystemmajrelease]}") }
+            it { is_expected.to contain_yumrepo('proxysql_repo').with_ensure('absent') }
+            it { is_expected.to contain_yumrepo('proxysql_1_4').with_ensure('absent') }
           end
 
           it do


### PR DESCRIPTION
Without this change yum will ignore upgrades from 1.4 to 2.0 if the 1.4
repo contains more recently updated packages than the 2.0 repo.

Fixes #137