### PR TITLE
PS-10287 Improve support for custom my.cnf

### DIFF
--- a/lib/facter/proxysql_mycnf_file_name.rb
+++ b/lib/facter/proxysql_mycnf_file_name.rb
@@ -1,0 +1,9 @@
+Facter.add(:proxysql_mycnf_file_name) do
+  setcode do
+    if File.exist? '/root/.proxysql_mycnf_file_name'
+      Facter::Core::Execution.execute('cat /root/.proxysql_mycnf_file_name')
+    else
+      '/root/.my.cnf'
+    end
+  end
+end

--- a/lib/puppet/provider/proxysql.rb
+++ b/lib/puppet/provider/proxysql.rb
@@ -9,7 +9,7 @@ class Puppet::Provider::Proxysql < Puppet::Provider
 
   # Optional defaults file
   def self.defaults_file
-    "--defaults-extra-file=#{Facter.value(:root_home)}/.my.cnf" if File.file?("#{Facter.value(:root_home)}/.my.cnf")
+    "--defaults-extra-file=#{Facter.value(:proxysql_mycnf_file_name)}" if File.file?("#{Facter.value(:proxysql_mycnf_file_name)}")
   end
 
   def defaults_file

--- a/lib/puppet/type/proxy_cluster.rb
+++ b/lib/puppet/type/proxy_cluster.rb
@@ -4,7 +4,7 @@ Puppet::Type.newtype(:proxy_cluster) do
 
   ensurable
 
-  autorequire(:file) { '/root/.my.cnf' }
+  autorequire(:class) { 'proxysql::admin_credentials' }
   autorequire(:class) { 'mysql::client' }
   autorequire(:service) { 'proxysql' }
 

--- a/lib/puppet/type/proxy_global_variable.rb
+++ b/lib/puppet/type/proxy_global_variable.rb
@@ -2,7 +2,7 @@
 Puppet::Type.newtype(:proxy_global_variable) do
   @doc = 'Manage a ProxySQL global variable.'
 
-  autorequire(:file) { '/root/.my.cnf' }
+  autorequire(:class) { 'proxysql::admin_credentials' }
   autorequire(:class) { 'mysql::client' }
   autorequire(:service) { 'proxysql' }
 

--- a/lib/puppet/type/proxy_mysql_galera_hostgroup.rb
+++ b/lib/puppet/type/proxy_mysql_galera_hostgroup.rb
@@ -3,7 +3,7 @@ require 'puppet/parameter/boolean'
 Puppet::Type.newtype(:proxy_mysql_galera_hostgroup) do
   @doc = 'Manage a ProxySQL mysql_galera_hostgroup.'
 
-  autorequire(:file) { '/root/.my.cnf' }
+  autorequire(:class) { 'proxysql::admin_credentials' }
   autorequire(:class) { 'mysql::client' }
   autorequire(:service) { 'proxysql' }
 

--- a/lib/puppet/type/proxy_mysql_group_replication_hostgroup.rb
+++ b/lib/puppet/type/proxy_mysql_group_replication_hostgroup.rb
@@ -4,7 +4,7 @@ Puppet::Type.newtype(:proxy_mysql_group_replication_hostgroup) do
 
   ensurable
 
-  autorequire(:file) { '/root/.my.cnf' }
+  autorequire(:class) { 'proxysql::admin_credentials' }
   autorequire(:class) { 'mysql::client' }
   autorequire(:service) { 'proxysql' }
 

--- a/lib/puppet/type/proxy_mysql_query_rule.rb
+++ b/lib/puppet/type/proxy_mysql_query_rule.rb
@@ -3,7 +3,7 @@ Puppet::Type.newtype(:proxy_mysql_query_rule) do
 
   ensurable
 
-  autorequire(:file) { '/root/.my.cnf' }
+  autorequire(:class) { 'proxysql::admin_credentials' }
   autorequire(:class) { 'mysql::client' }
   autorequire(:service) { 'proxysql' }
 

--- a/lib/puppet/type/proxy_mysql_replication_hostgroup.rb
+++ b/lib/puppet/type/proxy_mysql_replication_hostgroup.rb
@@ -4,7 +4,7 @@ Puppet::Type.newtype(:proxy_mysql_replication_hostgroup) do
 
   ensurable
 
-  autorequire(:file) { '/root/.my.cnf' }
+  autorequire(:class) { 'proxysql::admin_credentials' }
   autorequire(:class) { 'mysql::client' }
   autorequire(:service) { 'proxysql' }
 

--- a/lib/puppet/type/proxy_mysql_server.rb
+++ b/lib/puppet/type/proxy_mysql_server.rb
@@ -4,7 +4,7 @@ Puppet::Type.newtype(:proxy_mysql_server) do
 
   ensurable
 
-  autorequire(:file) { '/root/.my.cnf' }
+  autorequire(:class) { 'proxysql::admin_credentials' }
   autorequire(:class) { 'mysql::client' }
   autorequire(:service) { 'proxysql' }
 

--- a/lib/puppet/type/proxy_mysql_server_no_hostgroup.rb
+++ b/lib/puppet/type/proxy_mysql_server_no_hostgroup.rb
@@ -4,7 +4,7 @@ Puppet::Type.newtype(:proxy_mysql_server_no_hostgroup) do
 
   ensurable
 
-  autorequire(:file) { '/root/.my.cnf' }
+  autorequire(:class) { 'proxysql::admin_credentials' }
   autorequire(:class) { 'mysql::client' }
   autorequire(:service) { 'proxysql' }
 

--- a/lib/puppet/type/proxy_mysql_user.rb
+++ b/lib/puppet/type/proxy_mysql_user.rb
@@ -6,7 +6,7 @@ Puppet::Type.newtype(:proxy_mysql_user) do
 
   ensurable
 
-  autorequire(:file) { '/root/.my.cnf' }
+  autorequire(:class) { 'proxysql::admin_credentials' }
   autorequire(:class) { 'mysql::client' }
   autorequire(:service) { 'proxysql' }
 

--- a/lib/puppet/type/proxy_scheduler.rb
+++ b/lib/puppet/type/proxy_scheduler.rb
@@ -3,7 +3,7 @@ Puppet::Type.newtype(:proxy_scheduler) do
 
   ensurable
 
-  autorequire(:file) { '/root/.my.cnf' }
+  autorequire(:class) { 'proxysql::admin_credentials' }
   autorequire(:class) { 'mysql::client' }
   autorequire(:service) { 'proxysql' }
 

--- a/manifests/admin_credentials.pp
+++ b/manifests/admin_credentials.pp
@@ -32,6 +32,13 @@ class proxysql::admin_credentials {
       group   => $proxysql::sys_group,
       mode    => '0400',
     }
+
+    # This is to keep track of my cnf file.
+    # This is used by custom proxy_* resources
+    file { '/root/.proxysql_mycnf_file_name':
+      ensure  => file,
+      content => "${proxysql::mycnf_file_name}",
+    }
   }
 
 }


### PR DESCRIPTION
#### Pull Request (PR) description
* created fact, `proxysql_mycnf_file_name`,  for identifying custom my.cnf location
* Using Class['proxysql::admin_credentials] as autorequire instead of hardcoded `/root/.my.cnf`.
* This is needed when a custom mycnf location is being used.
