### PR TITLE
Stop creating spurious files

### DIFF
--- a/lib/puppet/provider/proxy_cluster/proxysql.rb
+++ b/lib/puppet/provider/proxy_cluster/proxysql.rb
@@ -4,7 +4,7 @@ Puppet::Type.type(:proxy_cluster).provide(:proxysql, parent: Puppet::Provider::P
   commands mysql: 'mysql'
 
   def self.mysql_running
-    system("mysql #{defaults_file} -NBe 'SELECT 1' >out 2>&1", out: '/dev/null')
+    system("mysql #{defaults_file} -NBe 'SELECT 1' 2>&1", out: '/dev/null')
   end
 
   # Build a property_hash containing all the discovered information about MySQL


### PR DESCRIPTION
With the current code, puppet will create a file named `out` with the output of `SELECT 1` in this file on each run in the current working dir.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
