### PR TITLE
provider: explicitly stringify output of mysql query

### DIFF
--- a/lib/puppet/provider/proxy_mysql_query_rule/proxysql.rb
+++ b/lib/puppet/provider/proxy_mysql_query_rule/proxysql.rb
@@ -23,7 +23,7 @@ Puppet::Type.type(:proxy_mysql_query_rule).provide(:proxysql, parent: Puppet::Pr
       @client_addr, @proxy_addr, @proxy_port, @destination_hostgroup,
       @digest, @match_digest, @match_pattern, @negate_match_pattern, @replace_pattern,
       @cache_ttl, @reconnect, @timeout, @retries, @delay, @error_msg, @log, @comment,
-      @mirror_flag_out, @mirror_hostgroup = mysql([defaults_file, '-NBe', query].compact).chomp.split(%r{\t})
+      @mirror_flag_out, @mirror_hostgroup = mysql([defaults_file, '-NBe', query].compact).to_s.chomp.split(%r{\t})
       name = "mysql_query_rule-#{rule_id}"
 
       instances << new(


### PR DESCRIPTION
Otherwise the result might corrupt the transactionstore.

For some reason some fields of the instance were still of the type `Puppet::Util::Execution::ProcessOutput` when puppet tries to serialize these into the `transactionstore.yaml` it adds the type.

When on a next run puppet tries to load the `transactionstore.yam` it thinks it's corrupted.
```
Transaction store file /opt/puppetlabs/puppet/cache/state/transactionstore.yaml is corrupt ((/opt/puppetlabs/puppet/cache/state/transactionstore.yaml): Tried to load unspecified class: Puppet::Util::Execution::ProcessOutput); replacing
Wrapped exception:
Tried to load unspecified class: Puppet::Util::Execution::ProcessOutput
```