### PR TITLE
Introduce `manage_mysql_client` boolean to toggle whether or not to include mysql::client

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,6 +28,10 @@
 #   Whether to create the required selinux rules for logrotate to work.  Defaults to `true`, but is only applicable to systems where SELinux is active (`enforcing` or `permissive`).
 #   This parameter also requires the `puppet/selinux` module to be installed.
 #
+# * `manage_mysql_client`
+#   Whether to include the mysql::client class. Defaults to `true`
+#   You may have mysql::client included or managed with different parameters elsewhere in your catalogue.
+#
 # * `listen_ip`
 #   The ip where the ProxySQL service will listen on. Defaults to '0.0.0.0' aka all configured IP's on the machine
 #
@@ -170,6 +174,7 @@ class proxysql (
   String $datadir = $proxysql::params::datadir,
   Stdlib::Filemode $datadir_mode = $proxysql::params::datadir_mode,
   Boolean $manage_selinux = true,
+  Boolean $manage_mysql_client = $proxysql::params::manage_mysql_client,
 
   String $listen_ip = $proxysql::params::listen_ip,
   Integer $listen_port = $proxysql::params::listen_port,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -174,7 +174,7 @@ class proxysql (
   String $datadir = $proxysql::params::datadir,
   Stdlib::Filemode $datadir_mode = $proxysql::params::datadir_mode,
   Boolean $manage_selinux = true,
-  Boolean $manage_mysql_client = $proxysql::params::manage_mysql_client,
+  Boolean $manage_mysql_client = true,
 
   String $listen_ip = $proxysql::params::listen_ip,
   Integer $listen_port = $proxysql::params::listen_port,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -45,15 +45,17 @@ class proxysql::install {
     mode   => $proxysql::datadir_mode,
   }
 
-  class { 'mysql::client':
-    package_name    => $proxysql::mysql_client_package_name,
-    bindings_enable => false,
+  if $proxysql::manage_mysql_client {
+    class { 'mysql::client':
+      package_name    => $proxysql::mysql_client_package_name,
+      bindings_enable => false,
+    }
+
+    Class['mysql::client::install']
+    -> Class['proxysql::admin_credentials']
+
+    Class['mysql::client::install']
+    -> Class['proxysql::reload_config']
   }
-
-  Class['mysql::client::install']
-  -> Class['proxysql::admin_credentials']
-
-  Class['mysql::client::install']
-  -> Class['proxysql::reload_config']
 
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -100,7 +100,6 @@ class proxysql::params {
   $manage_config_file       = true
   $proxy_config_file        = '/etc/proxysql_proxy.cnf'
   $manage_proxy_config_file = true
-  $manage_mysql_client      = true
 
   $mycnf_file_name   = '/root/.my.cnf'
   $manage_mycnf_file = true

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -100,6 +100,7 @@ class proxysql::params {
   $manage_config_file       = true
   $proxy_config_file        = '/etc/proxysql_proxy.cnf'
   $manage_proxy_config_file = true
+  $manage_mysql_client      = true
 
   $mycnf_file_name   = '/root/.my.cnf'
   $manage_mycnf_file = true


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Provide the ability to perform the inclusion of mysql::client elsewhere in the catalogue with more attributes than provided for by this module by introducing the manage_mysql_client boolean.
-->

