### PR TITLE
Gtid tracking support

### DIFF
--- a/lib/puppet/provider/proxy_mysql_server_no_hostgroup/proxysql.rb
+++ b/lib/puppet/provider/proxy_mysql_server_no_hostgroup/proxysql.rb
@@ -14,12 +14,18 @@ Puppet::Type.type(:proxy_mysql_server_no_hostgroup).provide(:proxysql, parent: P
     # one big swoop.
     servers.each do |line|
       hostname, port = line.split(%r{\t})
-      query = 'SELECT `hostname`, `port`, `hostgroup_id`, `status`, `weight`, `compression`, '
-      query << ' `max_connections`, `max_replication_lag`, `use_ssl`, `max_latency_ms`, `comment` '
+      query = 'SELECT `hostname`, `port`, `hostgroup_id`, '
+      if has_gtid_tracking?
+        query << ' `gtid_port`, '
+      else
+        query << " NULL AS 'gtid_port', "
+      end
+      query << ' `status`, `weight`, `compression`, `max_connections`, '
+      query << ' `max_replication_lag`, `use_ssl`, `max_latency_ms`, `comment` '
       query << ' FROM `mysql_servers`'
       query << " WHERE `hostname` =  '#{hostname}' AND `port` = #{port}"
 
-      @hostname, @port, @hostgroup_id, @status, @weight, @compression,
+      @hostname, @port, @hostgroup_id, @gtid_port, @status, @weight, @compression,
       @max_connections, @max_replication_lag, @use_ssl, @max_latency_ms,
       @comment = mysql([defaults_file, '-NBe', query].compact).chomp.split(%r{\t})
       name = "#{hostname}:#{port}"
@@ -29,6 +35,7 @@ Puppet::Type.type(:proxy_mysql_server_no_hostgroup).provide(:proxysql, parent: P
         ensure: :present,
         hostname: @hostname,
         port: @port,
+        gtid_port: @gtid_port,
         hostgroup_id: @hostgroup_id,
         status: @status,
         weight: @weight,
@@ -57,6 +64,7 @@ Puppet::Type.type(:proxy_mysql_server_no_hostgroup).provide(:proxysql, parent: P
     _name = @resource[:name]
     hostname = @resource.value(:hostname)
     port = @resource.value(:port) || 3306
+    gtid_port = @resource.value(:gtid_port)
     hostgroup_id = @resource.value(:hostgroup_id) || 0
     status = @resource.value(:status) || 'ONLINE'
     weight = @resource.value(:weight) || 1
@@ -67,10 +75,14 @@ Puppet::Type.type(:proxy_mysql_server_no_hostgroup).provide(:proxysql, parent: P
     max_latency_ms = @resource.value(:max_latency_ms) || 0
     comment = @resource.value(:comment) || ''
 
-    query = 'INSERT INTO mysql_servers (`hostname`, `port`, `hostgroup_id`, `status`, `weight`, `compression`, '
-    query << ' `max_connections`, `max_replication_lag`, `use_ssl`, `max_latency_ms`, `comment`)'
-    query << " VALUES ('#{hostname}', #{port}, #{hostgroup_id}, '#{status}', #{weight}, #{compression}, "
-    query << " #{max_connections}, #{max_replication_lag}, #{use_ssl}, #{max_latency_ms}, '#{comment}')"
+    query = 'INSERT INTO mysql_servers (`hostname`, `port`, `hostgroup_id`, '
+    query << ' `gtid_port`, ' if has_gtid_tracking?
+    query << ' `status`, `weight`, `compression`, `max_connections`, '
+    query << ' `max_replication_lag`, `use_ssl`, `max_latency_ms`, `comment`)'
+    query << " VALUES ('#{hostname}', #{port}, #{hostgroup_id}, "
+    query << " #{gtid_port}, " if has_gtid_tracking?
+    query << " '#{status}', #{weight}, #{compression}, #{max_connections}, "
+    query << " #{max_replication_lag}, #{use_ssl}, #{max_latency_ms}, '#{comment}')"
     mysql([defaults_file, '-e', query].compact)
     @property_hash[:ensure] = :present
 
@@ -162,5 +174,9 @@ Puppet::Type.type(:proxy_mysql_server_no_hostgroup).provide(:proxysql, parent: P
 
   def comment=(value)
     @property_flush[:comment] = value
+  end
+
+  def gtid_port=(value)
+    @property_flush[:gtid_port] = value
   end
 end

--- a/lib/puppet/provider/proxysql.rb
+++ b/lib/puppet/provider/proxysql.rb
@@ -16,6 +16,15 @@ class Puppet::Provider::Proxysql < Puppet::Provider
     self.class.defaults_file
   end
 
+  # Check if we're running a version of ProxySQL that supports GTID tracking
+  def self.has_gtid_tracking?
+    Facter.value(:proxysql_version) && Puppet::Util::Package.versioncmp(Facter.value(:proxysql_version), '2.0.1') >= 0
+  end
+
+  def has_gtid_tracking?
+    self.class.has_gtid_tracking?
+  end
+
   def make_sql_value(value)
     if value.nil?
       'NULL'

--- a/lib/puppet/type/proxy_mysql_server.rb
+++ b/lib/puppet/type/proxy_mysql_server.rb
@@ -49,6 +49,11 @@ Puppet::Type.newtype(:proxy_mysql_server) do
     newvalue(%r{\d+})
   end
 
+  newproperty(:gtid_port) do
+    desc 'the backend server port where ProxySQL Binlog Reader listens on for GTID tracking. ProxySQL 2.0+ only.'
+    newvalue(%r{\d+})
+  end
+
   newproperty(:status) do
     desc 'Server status.'
     newvalues(:ONLINE, :SHUNNED, :OFFLINE_SOFT, :OFFLINE_HARD)

--- a/lib/puppet/type/proxy_mysql_server_no_hostgroup.rb
+++ b/lib/puppet/type/proxy_mysql_server_no_hostgroup.rb
@@ -49,6 +49,11 @@ Puppet::Type.newtype(:proxy_mysql_server_no_hostgroup) do
     newvalue(%r{\d+})
   end
 
+  newproperty(:gtid_port) do
+    desc 'the backend server port where ProxySQL Binlog Reader listens on for GTID tracking. ProxySQL 2.0+ only.'
+    newvalue(%r{\d+})
+  end
+
   newproperty(:status) do
     desc 'Server status.'
     newvalues(:ONLINE, :SHUNNED, :OFFLINE_SOFT, :OFFLINE_HARD)

--- a/types/server.pp
+++ b/types/server.pp
@@ -1,6 +1,7 @@
 # lint:ignore:2sp_soft_tabs
 type Proxysql::Server = Array[Hash[String, Struct[{ Optional[port]                => Integer,
                                                     hostgroup_id                  => Integer,
+                                                    Optional[gtid_port]           => Integer,
                                                     Optional[status]              => String[1],
                                                     Optional[weight]              => Integer,
                                                     Optional[compression]         => Integer,
@@ -9,4 +10,4 @@ type Proxysql::Server = Array[Hash[String, Struct[{ Optional[port]              
                                                     Optional[use_ssl]             => Integer[0,1],
                                                     Optional[max_latency_ms]      => Integer,
                                                     Optional[comment]             => String[1], }],1,1]]
-# lint:endignore                                                 
+# lint:endignore


### PR DESCRIPTION
#### Pull Request (PR) description
ProxySQL 2.0.1+ includes a number of schema changes to support GTID tracking for casual consistency reads. The `proxy_mysql_server` and `proxy_mysql_server_no_hostgroup` types currently are not aware of the new `gtid_port` column in the `mysql_servers` table.

This PR adds 1) a function to the Proxysql parent provider class that indicates if the installed ProxySQL version has GTID tracking support (`has_gtid_tracking?`), which is based off the `proxysql_version` fact, and 2) support for `gtid_port` on `Proxysql::Server` types.

The changes are also backwards compatible. Older and unknown versions ignore the `gtid_port` parameter.

#### This Pull Request (PR) fixes the following issues
n/a
