### PR TITLE
Add ability to configure errorlog file path and mode

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -44,6 +44,16 @@ class proxysql::install {
     mode   => $proxysql::datadir_mode,
   }
 
+  if $proxysql::errorlog_file {
+    file { $proxysql::errorlog_file:
+      ensure => file,
+      path   => $proxysql::errorlog_file,
+      owner  => $proxysql::errorlog_file_owner,
+      group  => $proxysql::errorlog_file_group,
+      mode   => $proxysql::errorlog_file_mode,
+    }
+  }
+
   if $proxysql::manage_mysql_client {
     class { 'mysql::client':
       package_name    => $proxysql::mysql_client_package_name,


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Currently there is no property to set errorlog file path and mode. Hence the installation uses the default path defined at the library level.

#### This Pull Request (PR) fixes the following issues
This PR exposes 2 new parameters, 1 to set errorlog file path and other to set the file path mode/permissions.

