### PR TITLE
Normalise pattern values (match, negate_match, replace)

### DIFF
--- a/lib/puppet/provider/proxy_mysql_query_rule/proxysql.rb
+++ b/lib/puppet/provider/proxy_mysql_query_rule/proxysql.rb
@@ -3,6 +3,15 @@ Puppet::Type.type(:proxy_mysql_query_rule).provide(:proxysql, parent: Puppet::Pr
   desc 'Manage query rule for a ProxySQL instance.'
   commands mysql: 'mysql'
 
+  def self.normalise_pattern(pattern)
+    if pattern.nil?
+      return nil
+    end
+    retval = pattern.gsub('\\\\', '\\')
+    retval.gsub!("'", "''")
+    return retval
+  end
+
   # Build a property_hash containing all the discovered information about query rules.
   def self.instances
     instances = []
@@ -25,6 +34,10 @@ Puppet::Type.type(:proxy_mysql_query_rule).provide(:proxysql, parent: Puppet::Pr
       @cache_ttl, @reconnect, @timeout, @retries, @delay, @error_msg, @log, @comment,
       @mirror_flag_out, @mirror_hostgroup = mysql([defaults_file, '-NBe', query].compact).to_s.chomp.split(%r{\t})
       name = "mysql_query_rule-#{rule_id}"
+
+      @match_pattern = normalise_pattern(@match_pattern)
+      @negate_match_pattern = normalise_pattern(@negate_match_pattern)
+      @replace_pattern = normalise_pattern(@replace_pattern)
 
       instances << new(
         name: name,


### PR DESCRIPTION
### Pull Request (PR) description
This is my initial PR that works for me, but is probably not the best way to achieve the result. The underlying issue I found is twofold:

-  YAML requires escaping of certain values - in my case '.
- The mysql() function used in self.instances returns a string with backslashes escaping some chars/

I resolved this by modifying the value that is retrieved from MySQL to match what is provided from the YAML file. A better method would be to normalise both string formats and unescape them, but I don't know how to modify the value that is supplied from hiera.

#### This Pull Request (PR) fixes the following issues
Fixes #90
