### PR TITLE
Add support for Ubuntu 20.04

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,7 +9,7 @@ class proxysql::params {
       $package_provider = 'dpkg'
       $package_dependencies = []
 
-      if $facts['os']['release']['major'] == '18.04' {
+      if versioncmp(fact('os.release.major'), '18.04') >= 0 {
         # The 2.0.x systemd service file in ubuntu 18.04 has `ReadWritePaths=/var/lib/proxysql /var/run/proxysql`.
         # This limits where we can write sockets.
         $_listen_socket = "${datadir}/proxysql.sock"

--- a/metadata.json
+++ b/metadata.json
@@ -70,7 +70,8 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "18.04"
+        "18.04",
+        "20.04"
       ]
     }
   ],

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper_acceptance'
 
 describe 'proxysql class' do
-  unless fact('os.release.major') == '18.04' ||
+  unless ['18.04', '20.04'].include?(fact('os.release.major')) ||
          (fact('os.name') == 'Debian' && fact('os.release.major') == '10') # There are no proxysql 1.4 packages for these OSes
     context 'version 1.4' do
       it 'works idempotently with no errors' do

--- a/spec/classes/proxysql_spec.rb
+++ b/spec/classes/proxysql_spec.rb
@@ -48,7 +48,7 @@ describe 'proxysql' do
           sys_user = 'proxysql'
           sys_group = 'proxysql'
 
-          admin_socket = if facts[:operatingsystemrelease] == '18.04'
+          admin_socket = if ['18.04', '20.04'].include?(facts[:operatingsystemrelease])
                            '/var/lib/proxysql/proxysql_admin.sock'
                          else
                            '/tmp/proxysql_admin.sock'
@@ -99,7 +99,7 @@ describe 'proxysql' do
           end
 
           unless (facts[:osfamily] == 'RedHat' && facts[:operatingsystemmajrelease] == '7') ||
-                 (facts[:operatingsystem] == 'Ubuntu' && facts[:operatingsystemmajrelease] == '18.04') ||
+                 (facts[:operatingsystem] == 'Ubuntu' && ['18.04', '20.04'].include?(facts[:operatingsystemmajrelease])) ||
                  (facts[:operatingsystem] == 'Debian' && facts[:operatingsystemmajrelease] =~ %r{^(9|10)$})
             it { is_expected.to contain_service('proxysql').with_hasstatus(true) }
             it { is_expected.to contain_service('proxysql').with_hasrestart(true) }


### PR DESCRIPTION
#### Pull Request (PR) description

In Ubuntu 18.04 and 20.04 (and presumably any systemd-based Ubuntu version), the admin socket for proxysql lives in ${datadir}. Currently,  the module looks for the admin socket in `/tmp` on Ubuntu 20.04, and errors out. This change fixes that issue for Ubuntu 20.04 and any future version of Ubuntu.

#### This Pull Request (PR) fixes the following issues
n/a
