### PR TITLE
Newer proxysql support

### DIFF
--- a/lib/puppet/type/proxy_mysql_query_rule.rb
+++ b/lib/puppet/type/proxy_mysql_query_rule.rb
@@ -90,12 +90,12 @@ Puppet::Type.newtype(:proxy_mysql_query_rule) do
 
   newproperty(:match_pattern) do
     desc 'regular expression that matches the query text'
-    newvalue(%r{\w+})
+    newvalue(%r{.*})
   end
 
   newproperty(:replace_pattern) do
     desc 'this is the pattern with which to replace the matched pattern.'
-    newvalue(%r{\w+})
+    newvalue(%r{.*})
   end
 
   newproperty(:negate_match_pattern) do

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -36,6 +36,36 @@ class proxysql::params {
           'server' => 'keyserver.ubuntu.com',
         },
       }
+      $repo21             = {
+        comment  => 'ProxySQL 2.1.x APT repository',
+        location => "http://repo.proxysql.com/ProxySQL/proxysql-2.1.x/${facts['os']['distro']['codename']}/",
+        release  => './',
+        repos    => '',
+        key      => {
+          'id'     => '1448BF693CA600C799EB935804A562FB79953B49',
+          'server' => 'keyserver.ubuntu.com',
+        },
+      }
+      $repo22             = {
+        comment  => 'ProxySQL 2.2.x APT repository',
+        location => "http://repo.proxysql.com/ProxySQL/proxysql-2.2.x/${facts['os']['distro']['codename']}/",
+        release  => './',
+        repos    => '',
+        key      => {
+          'id'     => '1448BF693CA600C799EB935804A562FB79953B49',
+          'server' => 'keyserver.ubuntu.com',
+        },
+      }
+      $repo23             = {
+        comment  => 'ProxySQL 2.3.x APT repository',
+        location => "http://repo.proxysql.com/ProxySQL/proxysql-2.3.x/${facts['os']['distro']['codename']}/",
+        release  => './',
+        repos    => '',
+        key      => {
+          'id'     => '1448BF693CA600C799EB935804A562FB79953B49',
+          'server' => 'keyserver.ubuntu.com',
+        },
+      }
     }
     'RedHat': {
       $package_provider = 'rpm'
@@ -56,6 +86,30 @@ class proxysql::params {
         name     => 'proxysql_2_0',
         descr    => 'ProxySQL 2.0.x YUM repository',
         baseurl  => "http://repo.proxysql.com/ProxySQL/proxysql-2.0.x/centos/${repo_os_major_version}",
+        enabled  => true,
+        gpgcheck => true,
+        gpgkey   => 'http://repo.proxysql.com/ProxySQL/repo_pub_key',
+      }
+      $repo21             = {
+        name     => 'proxysql_2_1',
+        descr    => 'ProxySQL 2.1.x YUM repository',
+        baseurl  => "http://repo.proxysql.com/ProxySQL/proxysql-2.1.x/centos/${repo_os_major_version}",
+        enabled  => true,
+        gpgcheck => true,
+        gpgkey   => 'http://repo.proxysql.com/ProxySQL/repo_pub_key',
+      }
+      $repo22             = {
+        name     => 'proxysql_2_2',
+        descr    => 'ProxySQL 2.2.x YUM repository',
+        baseurl  => "http://repo.proxysql.com/ProxySQL/proxysql-2.2.x/centos/${repo_os_major_version}",
+        enabled  => true,
+        gpgcheck => true,
+        gpgkey   => 'http://repo.proxysql.com/ProxySQL/repo_pub_key',
+      }
+      $repo23             = {
+        name     => 'proxysql_2_3',
+        descr    => 'ProxySQL 2.3.x YUM repository',
+        baseurl  => "http://repo.proxysql.com/ProxySQL/proxysql-2.3.x/centos/${repo_os_major_version}",
         enabled  => true,
         gpgcheck => true,
         gpgkey   => 'http://repo.proxysql.com/ProxySQL/repo_pub_key',

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -25,13 +25,36 @@ class proxysql::repo {
           * => $repo,
         }
 
-        # $purge_repo = $proxysql::version ? {
-        #   /^2\.0\./ => $proxysql::params::repo14['name'],
-        #   /^1\.4\./ => $proxysql::params::repo20['name'],
-        # }
-        # yumrepo { ['proxysql_repo', $purge_repo]:
-        #   ensure => absent,
-        # }
+        # Purge old/unnecessary repos.
+        if ($proxysql::version !~ /^2\.3\./) {
+          yumrepo { $proxysql::params::repo23['name']:
+            ensure => absent,
+          }
+        }
+        if ($proxysql::version !~ /^2\.2\./) {
+          yumrepo { $proxysql::params::repo22['name']:
+            ensure => absent,
+          }
+        }
+        if ($proxysql::version !~ /^2\.1\./) {
+          yumrepo { $proxysql::params::repo21['name']:
+            ensure => absent,
+          }
+        }
+        if ($proxysql::version !~ /^2\.0\./) {
+          yumrepo { $proxysql::params::repo20['name']:
+            ensure => absent,
+          }
+        }
+        if ($proxysql::version !~ /^1\.4\./) {
+          yumrepo { $proxysql::params::repo14['name']:
+            ensure => absent,
+          }
+        }
+
+        yumrepo { 'proxysql_repo':
+          ensure => absent,
+        }
       }
       default: {
         fail('This operatingsystem is not supported (yet).')

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -6,6 +6,9 @@ class proxysql::repo {
 
   if $proxysql::manage_repo and !$proxysql::package_source {
     $repo = $proxysql::version ? {
+      /^2\.3\./ => $proxysql::params::repo23,
+      /^2\.2\./ => $proxysql::params::repo22,
+      /^2\.1\./ => $proxysql::params::repo21,
       /^2\.0\./ => $proxysql::params::repo20,
       /^1\.4\./ => $proxysql::params::repo14,
       default   => fail("Unsupported `proxysql::version` ${proxysql::version}")
@@ -22,13 +25,13 @@ class proxysql::repo {
           * => $repo,
         }
 
-        $purge_repo = $proxysql::version ? {
-          /^2\.0\./ => $proxysql::params::repo14['name'],
-          /^1\.4\./ => $proxysql::params::repo20['name'],
-        }
-        yumrepo { ['proxysql_repo', $purge_repo]:
-          ensure => absent,
-        }
+        # $purge_repo = $proxysql::version ? {
+        #   /^2\.0\./ => $proxysql::params::repo14['name'],
+        #   /^1\.4\./ => $proxysql::params::repo20['name'],
+        # }
+        # yumrepo { ['proxysql_repo', $purge_repo]:
+        #   ensure => absent,
+        # }
       }
       default: {
         fail('This operatingsystem is not supported (yet).')


### PR DESCRIPTION
#### Pull Request (PR) description
This PR adds very simple support for newer ProxySQL versions.  In my case I'm using 2.3 but I added the ones in between.  One big caveat is that I removed the cleanup of old versions in the process.  Frankly.. because it was going to be incredibly ugly code to clean up.  That said if you feel strongly about that, I can add it back.

It also adjusts the accepted regex patterns because stuff like: ^.*$ was not working because it had no word characters.
