### PR TITLE
Support 2.5.x

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -76,6 +76,16 @@ class proxysql::params {
           'server' => 'keyserver.ubuntu.com',
         },
       }
+      $repo25             = {
+        comment  => 'ProxySQL 2.5.x APT repository',
+        location => "http://repo.proxysql.com/ProxySQL/proxysql-2.5.x/${facts['os']['distro']['codename']}/",
+        release  => './',
+        repos    => '',
+        key      => {
+          'id'     => '1448BF693CA600C799EB935804A562FB79953B49',
+          'server' => 'keyserver.ubuntu.com',
+        },
+      }
     }
     'RedHat': {
       $package_provider = 'rpm'
@@ -128,6 +138,14 @@ class proxysql::params {
         name     => 'proxysql_2_4',
         descr    => 'ProxySQL 2.4.x YUM repository',
         baseurl  => "http://repo.proxysql.com/ProxySQL/proxysql-2.4.x/centos/${repo_os_major_version}",
+        enabled  => true,
+        gpgcheck => true,
+        gpgkey   => 'http://repo.proxysql.com/ProxySQL/repo_pub_key',
+      }
+      $repo25             = {
+        name     => 'proxysql_2_5',
+        descr    => 'ProxySQL 2.5.x YUM repository',
+        baseurl  => "http://repo.proxysql.com/ProxySQL/proxysql-2.5.x/centos/${repo_os_major_version}",
         enabled  => true,
         gpgcheck => true,
         gpgkey   => 'http://repo.proxysql.com/ProxySQL/repo_pub_key',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -66,6 +66,16 @@ class proxysql::params {
           'server' => 'keyserver.ubuntu.com',
         },
       }
+      $repo24             = {
+        comment  => 'ProxySQL 2.4.x APT repository',
+        location => "http://repo.proxysql.com/ProxySQL/proxysql-2.4.x/${facts['os']['distro']['codename']}/",
+        release  => './',
+        repos    => '',
+        key      => {
+          'id'     => '1448BF693CA600C799EB935804A562FB79953B49',
+          'server' => 'keyserver.ubuntu.com',
+        },
+      }
     }
     'RedHat': {
       $package_provider = 'rpm'
@@ -110,6 +120,14 @@ class proxysql::params {
         name     => 'proxysql_2_3',
         descr    => 'ProxySQL 2.3.x YUM repository',
         baseurl  => "http://repo.proxysql.com/ProxySQL/proxysql-2.3.x/centos/${repo_os_major_version}",
+        enabled  => true,
+        gpgcheck => true,
+        gpgkey   => 'http://repo.proxysql.com/ProxySQL/repo_pub_key',
+      }
+      $repo24             = {
+        name     => 'proxysql_2_4',
+        descr    => 'ProxySQL 2.4.x YUM repository',
+        baseurl  => "http://repo.proxysql.com/ProxySQL/proxysql-2.4.x/centos/${repo_os_major_version}",
         enabled  => true,
         gpgcheck => true,
         gpgkey   => 'http://repo.proxysql.com/ProxySQL/repo_pub_key',

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -6,6 +6,8 @@ class proxysql::repo {
 
   if $proxysql::manage_repo and !$proxysql::package_source {
     $repo = $proxysql::version ? {
+      /^2\.5\./ => $proxysql::params::repo25,
+      /^2\.4\./ => $proxysql::params::repo24,
       /^2\.3\./ => $proxysql::params::repo23,
       /^2\.2\./ => $proxysql::params::repo22,
       /^2\.1\./ => $proxysql::params::repo21,
@@ -26,6 +28,16 @@ class proxysql::repo {
         }
 
         # Purge old/unnecessary repos.
+        if ($proxysql::version !~ /^2\.5\./) {
+          yumrepo { $proxysql::params::repo25['name']:
+            ensure => absent,
+          }
+        }
+        if ($proxysql::version !~ /^2\.4\./) {
+          yumrepo { $proxysql::params::repo24['name']:
+            ensure => absent,
+          }
+        }
         if ($proxysql::version !~ /^2\.3\./) {
           yumrepo { $proxysql::params::repo23['name']:
             ensure => absent,


### PR DESCRIPTION
Builds on top of my last PR that adds support for 2.4.x by adding YUM and APT repository paths for these versions of ProxySQL.
