### PR TITLE
puppetlabs/mysql: Allow 14.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs-mysql",
-      "version_requirement": ">= 2.5.0 < 13.0.0"
+      "version_requirement": ">= 2.5.0 < 14.0.0"
     },
     {
       "name": "puppetlabs-apt",


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
The change in this code snippet updates the version requirement for the "puppetlabs-mysql" module. It changes the requirement from ">= 2.5.0 < 13.0.0" to ">= 2.5.0 < 14.0.0".

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
