### PR TITLE
puppetlabs/apt: Allow 9.1.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs-apt",
-      "version_requirement": ">= 2.1.0 < 9.0.0"
+      "version_requirement": ">= 2.1.0 < 9.1.0"
     },
     {
       "name": "puppetlabs-stdlib",


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
The change in this code snippet updates the version requirement for the "puppetlabs-apt" module. It changes the requirement from ">= 2.1.0 < 9.0.0" to ">= 2.1.0 < 9.1.0".

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
