### PR TITLE
drop OracleLinux 7 as supported OS

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -54,7 +54,6 @@
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "7",
         "8",
         "9"
       ]


### PR DESCRIPTION
drop OracleLinux 7 as supported OS