### PR TITLE
allow puppetlabs/apt <= 10.0.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs-apt",
-      "version_requirement": ">= 2.1.0 < 9.0.0"
+      "version_requirement": ">= 2.1.0 < 10.0.0"
     },
     {
       "name": "puppetlabs-stdlib",


### PR DESCRIPTION
allow puppetlabs/apt <= 10.0.0

fixes #205