### PR TITLE
allow puppet/extlib <= 8.0.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "puppet-extlib",
-      "version_requirement": ">= 2.1.0 < 7.0.0"
+      "version_requirement": ">= 2.1.0 < 8.0.0"
     },
     {
       "name": "puppet/systemd",


### PR DESCRIPTION
allow puppet/extlib <= 8.0.0

fixes #214 