### PR TITLE
Add multiplex support for proxy_mysql_query_rule

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -980,6 +980,14 @@ Valid values: `%r{\w+}`
 
 match queries with a specific digest, as returned by stats_mysql_query_digest.digest
 
+##### `multiplex`
+
+Valid values: `1`, `0`
+
+Defines if the Query Rule is multiplex or not
+
+Default value: `undef`
+
 ##### `ensure`
 
 Valid values: `present`, `absent`

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -984,7 +984,7 @@ match queries with a specific digest, as returned by stats_mysql_query_digest.di
 
 Valid values: `1`, `0`
 
-Defines if the Query Rule is multiplex or not
+Defines if the Query Rule is multiplex or not. This means that if the same query is executed multiple times, only the first one will be sent to the backend, and the result will be returned to all clients. This is useful for queries that are executed very often, and return the same result, like "SELECT 1".'
 
 Default value: `undef`
 
@@ -1776,6 +1776,7 @@ Array[Hash[String, Struct[{ rule_id                         => Integer,
   Optional[error_msg]             => String[1],
   Optional[log]                   => Integer[0,1],
   Optional[mirror_hostgroup]      => Integer,
+  Optional[multiplex]             => String[1]
 Optional[mirror_flag_out]       => Integer, }],1,1]]
 ```
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -982,11 +982,9 @@ match queries with a specific digest, as returned by stats_mysql_query_digest.di
 
 ##### `multiplex`
 
-Valid values: `1`, `0`
+Valid values: `%r{[\w+]}`
 
-Defines if the Query Rule is multiplex or not. This means that if the same query is executed multiple times, only the first one will be sent to the backend, and the result will be returned to all clients. This is useful for queries that are executed very often, and return the same result, like "SELECT 1".'
-
-Default value: `undef`
+Defines if the Query Rule is multiplex or not Set to 1, 0 or NULL. This means that if the same query is executed multiple times, only the first one will be sent to the backend, and the result will be returned to all clients. This is useful for queries that are executed very often, and return the same result, like "SELECT 1".'
 
 ##### `ensure`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -980,12 +980,6 @@ Valid values: `%r{\w+}`
 
 match queries with a specific digest, as returned by stats_mysql_query_digest.digest
 
-##### `multiplex`
-
-Valid values: `%r{[\w+]}`
-
-Defines if the Query Rule is multiplex or not Set to 1, 0 or NULL. This means that if the same query is executed multiple times, only the first one will be sent to the backend, and the result will be returned to all clients. This is useful for queries that are executed very often, and return the same result, like "SELECT 1".'
-
 ##### `ensure`
 
 Valid values: `present`, `absent`
@@ -1041,6 +1035,12 @@ see https://github.com/sysown/proxysql/blob/master/doc/mirroring.md
 Valid values: `%r{\d+}`
 
 see https://github.com/sysown/proxysql/blob/master/doc/mirroring.md.
+
+##### `multiplex`
+
+Valid values: `%r{\w+}`
+
+if this is set to 1, the query will be multiplexed. This means that if the same query is executed multiple times, only the first one will be sent to the backend, and the result will be returned to all clients. This is useful for queries that are executed very often, and return the same result, like "SELECT 1".
 
 ##### `negate_match_pattern`
 
@@ -1774,7 +1774,7 @@ Array[Hash[String, Struct[{ rule_id                         => Integer,
   Optional[error_msg]             => String[1],
   Optional[log]                   => Integer[0,1],
   Optional[mirror_hostgroup]      => Integer,
-  Optional[multiplex]             => String[1]
+  Optional[multiplex]             => String[1],
 Optional[mirror_flag_out]       => Integer, }],1,1]]
 ```
 

--- a/lib/puppet/provider/proxy_mysql_query_rule/proxysql.rb
+++ b/lib/puppet/provider/proxy_mysql_query_rule/proxysql.rb
@@ -26,14 +26,14 @@ Puppet::Type.type(:proxy_mysql_query_rule).provide(:proxysql, parent: Puppet::Pr
               '`client_addr`, `proxy_addr`, `proxy_port`, `destination_hostgroup`,  ' \
               '`digest`, `match_digest`, `match_pattern`, `negate_match_pattern`, `replace_pattern`,  ' \
               '`cache_ttl`, `reconnect`, `timeout`, `retries`, `delay`, `error_msg`, `log`, `comment`,  ' \
-              '`mirror_flagOUT`, `mirror_hostgroup` ' \
+              '`mirror_flagOUT`, `mirror_hostgroup`, `multiplex` ' \
               "FROM `mysql_query_rules` WHERE rule_id = '#{rule_id}'"
 
       @active, @username, @schemaname, @flag_in, @flag_out, @apply,
       @client_addr, @proxy_addr, @proxy_port, @destination_hostgroup,
       @digest, @match_digest, @match_pattern, @negate_match_pattern, @replace_pattern,
       @cache_ttl, @reconnect, @timeout, @retries, @delay, @error_msg, @log, @comment,
-      @mirror_flag_out, @mirror_hostgroup = mysql([defaults_file, '-NBe', query].compact).to_s.chomp.split(%r{\t})
+      @mirror_flag_out, @mirror_hostgroup, @multiplex = mysql([defaults_file, '-NBe', query].compact).to_s.chomp.split(%r{\t})
       name = "mysql_query_rule-#{rule_id}"
 
       @match_pattern = normalise_pattern(@match_pattern)
@@ -69,6 +69,7 @@ Puppet::Type.type(:proxy_mysql_query_rule).provide(:proxysql, parent: Puppet::Pr
         comment: @comment,
         mirror_flag_out: @mirror_flag_out,
         mirror_hostgroup: @mirror_hostgroup,
+        multiplex: @multiplex,
       )
     end
     instances
@@ -112,18 +113,18 @@ Puppet::Type.type(:proxy_mysql_query_rule).provide(:proxysql, parent: Puppet::Pr
     comment = make_sql_value(@resource.value(:comment) || nil)
     mirror_flag_out = make_sql_value(@resource.value(:mirror_flag_out) || nil)
     mirror_hostgroup = make_sql_value(@resource.value(:mirror_hostgroup) || nil)
-
+    multiplex = make_sql_value(@resource.value(:multiplex) || nil)
     query = 'INSERT INTO `mysql_query_rules` (' \
             '`rule_id`, `active`, `username`, `schemaname`, `flagIN`, `flagOUT`, `apply`, ' \
             '`client_addr`, `proxy_addr`, `proxy_port`, `destination_hostgroup`, ' \
             '`digest`, `match_digest`, `match_pattern`, `negate_match_pattern`, `replace_pattern`, ' \
             '`cache_ttl`, `reconnect`, `timeout`, `retries`, `delay`, `error_msg`, `log`, `comment`, ' \
-            '`mirror_flagOUT`, `mirror_hostgroup`) VALUES (' \
+            '`mirror_flagOUT`, `mirror_hostgroup`, `multiplex`) VALUES (' \
             "#{rule_id}, #{active}, #{username}, #{schemaname}, #{flag_in}, #{flag_out}, #{apply}, " \
             "#{client_addr}, #{proxy_addr}, #{proxy_port}, #{destination_hostgroup}, " \
             "#{digest}, #{match_digest}, #{match_pattern}, #{negate_match_pattern}, #{replace_pattern}, " \
             "#{cache_ttl}, #{reconnect}, #{timeout}, #{retries}, #{delay}, #{error_msg}, #{log}, #{comment}, " \
-            "#{mirror_flag_out}, #{mirror_hostgroup})"
+            "#{mirror_flag_out}, #{mirror_hostgroup}, #{multiplex})"
     mysql([defaults_file, '-e', query].compact)
     @property_hash[:ensure] = :present
 
@@ -275,5 +276,9 @@ Puppet::Type.type(:proxy_mysql_query_rule).provide(:proxysql, parent: Puppet::Pr
 
   def mirror_hostgroup=(value)
     @property_flush[:mirror_hostgroup] = value
+  end
+
+  def multiplex=(value)
+    @property_flush[:multiplex] = value
   end
 end

--- a/lib/puppet/type/proxy_mysql_query_rule.rb
+++ b/lib/puppet/type/proxy_mysql_query_rule.rb
@@ -87,7 +87,7 @@ Puppet::Type.newtype(:proxy_mysql_query_rule) do
 
   newproperty(:multiplex) do
     desc 'if this is set to 1, the query will be multiplexed. This means that if the same query is executed multiple times, only the first one will be sent to the backend, and the result will be returned to all clients. This is useful for queries that are executed very often, and return the same result, like "SELECT 1".'
-    newvalue(%r{[01]})
+    newvalue(%r{\w+})
   end
 
   newproperty(:match_digest) do

--- a/lib/puppet/type/proxy_mysql_query_rule.rb
+++ b/lib/puppet/type/proxy_mysql_query_rule.rb
@@ -85,6 +85,11 @@ Puppet::Type.newtype(:proxy_mysql_query_rule) do
     newvalue(%r{\w+})
   end
 
+  newproperty(:multiplex) do
+    desc 'if this is set to 1, the query will be multiplexed. This means that if the same query is executed multiple times, only the first one will be sent to the backend, and the result will be returned to all clients. This is useful for queries that are executed very often, and return the same result, like "SELECT 1".'
+    newvalue(%r{[01]})
+  end
+
   newproperty(:match_digest) do
     desc 'regular expression that matches the query digest'
     newvalue(%r{\w+})

--- a/types/rule.pp
+++ b/types/rule.pp
@@ -23,4 +23,5 @@ type Proxysql::Rule = Array[Hash[String, Struct[{ rule_id                       
   Optional[error_msg]             => String[1],
   Optional[log]                   => Integer[0,1],
   Optional[mirror_hostgroup]      => Integer,
+  Optional[multiplex]             => Integer[0,1],
 Optional[mirror_flag_out]       => Integer, }],1,1]]

--- a/types/rule.pp
+++ b/types/rule.pp
@@ -23,5 +23,5 @@ type Proxysql::Rule = Array[Hash[String, Struct[{ rule_id                       
   Optional[error_msg]             => String[1],
   Optional[log]                   => Integer[0,1],
   Optional[mirror_hostgroup]      => Integer,
-  Optional[multiplex]             => Integer[0,1],
+  Optional[multiplex]             => String[1],
 Optional[mirror_flag_out]       => Integer, }],1,1]]

--- a/types/rule.pp
+++ b/types/rule.pp
@@ -23,5 +23,5 @@ type Proxysql::Rule = Array[Hash[String, Struct[{ rule_id                       
   Optional[error_msg]             => String[1],
   Optional[log]                   => Integer[0,1],
   Optional[mirror_hostgroup]      => Integer,
-  Optional[multiplex]             => String[1],
+  Optional[multiplex]             => Optional[String[1]],
 Optional[mirror_flag_out]       => Integer, }],1,1]]

--- a/types/rule.pp
+++ b/types/rule.pp
@@ -23,5 +23,5 @@ type Proxysql::Rule = Array[Hash[String, Struct[{ rule_id                       
   Optional[error_msg]             => String[1],
   Optional[log]                   => Integer[0,1],
   Optional[mirror_hostgroup]      => Integer,
-  Optional[multiplex]             => Optional[String[1]],
+  Optional[multiplex]             => String[1],
 Optional[mirror_flag_out]       => Integer, }],1,1]]


### PR DESCRIPTION
#### Pull Request (PR) description

This PR introduces full support for the multiplex field in ProxySQL query rules managed by this module.

- Adds multiplex as a first-class query rule attribute in Puppet.
- Supports explicit multiplex values for enabled and disabled behavior.
- Supports resetting multiplex to SQL NULL
- Keeps existing query rule behavior unchanged for users who do not set multiplex.
- 
Backward compatibility
This is backward compatible. Existing users who do not set multiplex are unaffected.


#### This Pull Request (PR) fixes the following issues
Fixes #252

