### PR TITLE
fix: expose encrypt_password in Proxysql::User type alias

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1825,6 +1825,7 @@ Array[Hash[String, Struct[{ password                         => String[1],
   Optional[fast_forward]           => Integer[0,1],
   Optional[backend]                => Integer[0,1],
   Optional[frontend]               => Integer[0,1],
-Optional[max_connections]        => Integer, }],1,1]]
+  Optional[max_connections]        => Integer,
+  Optional[encrypt_password]       => Boolean, }],1,1]]
 ```
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1826,6 +1826,7 @@ Array[Hash[String, Struct[{ password                         => String[1],
   Optional[backend]                => Integer[0,1],
   Optional[frontend]               => Integer[0,1],
   Optional[max_connections]        => Integer,
-  Optional[encrypt_password]       => Boolean, }],1,1]]
+  Optional[encrypt_password]       => Boolean,
+}],1,1]]
 ```
 

--- a/types/user.pp
+++ b/types/user.pp
@@ -9,4 +9,5 @@ type Proxysql::User = Array[Hash[String, Struct[{ password                      
   Optional[fast_forward]           => Integer[0,1],
   Optional[backend]                => Integer[0,1],
   Optional[frontend]               => Integer[0,1],
-Optional[max_connections]        => Integer, }],1,1]]
+  Optional[max_connections]        => Integer,
+  Optional[encrypt_password]       => Boolean, }],1,1]]

--- a/types/user.pp
+++ b/types/user.pp
@@ -10,4 +10,5 @@ type Proxysql::User = Array[Hash[String, Struct[{ password                      
   Optional[backend]                => Integer[0,1],
   Optional[frontend]               => Integer[0,1],
   Optional[max_connections]        => Integer,
-  Optional[encrypt_password]       => Boolean, }],1,1]]
+  Optional[encrypt_password]       => Boolean,
+}],1,1]]


### PR DESCRIPTION
The proxy_mysql_user Ruby type already supports the encrypt_password parameter (lib/puppet/type/proxy_mysql_user.rb), which skips SHA1 hashing when set to false. However, the Proxysql::User Puppet type alias (types/user.pp) did not include it, causing Puppet catalog compilation to fail with "unrecognized key 'encrypt_password'" when the parameter was set via Hiera.

This is needed for users with caching_sha2_password hashes (prefixed $A$005$), which are already hashed by MySQL and must not be re-hashed using the mysql_native_password SHA1 logic. Without encrypt_password: false, ProxySQL would store a double-hashed value and all frontend authentication for such users would fail.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
